### PR TITLE
feat: Epic 6 — Monetization Configuration

### DIFF
--- a/backend/app/routers/series.py
+++ b/backend/app/routers/series.py
@@ -13,7 +13,14 @@ from app.middleware.auth import get_current_user
 from app.models.series import Series, SeriesStatus, series_tags
 from app.models.tag import Tag
 from app.models.user import User
-from app.schemas.series import SeriesCreate, SeriesListResponse, SeriesResponse, SeriesUpdate
+from app.schemas.series import (
+    PricingResponse,
+    PricingUpdate,
+    SeriesCreate,
+    SeriesListResponse,
+    SeriesResponse,
+    SeriesUpdate,
+)
 
 router = APIRouter(prefix="/api/series", tags=["series"])
 
@@ -214,3 +221,49 @@ async def delete_series(
 
     series.status = SeriesStatus.archived
     await db.commit()
+
+
+@router.get("/{series_id}/pricing", response_model=PricingResponse)
+async def get_pricing(
+    series_id: uuid.UUID,
+    _user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Get pricing configuration for a series."""
+    result = await db.execute(select(Series).where(Series.id == series_id))
+    series = result.scalar_one_or_none()
+
+    if series is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Series not found",
+        )
+
+    return series
+
+
+@router.patch("/{series_id}/pricing", response_model=PricingResponse)
+async def update_pricing(
+    series_id: uuid.UUID,
+    request: PricingUpdate,
+    _user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Update pricing configuration for a series."""
+    result = await db.execute(select(Series).where(Series.id == series_id))
+    series = result.scalar_one_or_none()
+
+    if series is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Series not found",
+        )
+
+    update_data = request.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(series, field, value)
+
+    await db.commit()
+    await db.refresh(series)
+
+    return series

--- a/backend/app/schemas/series.py
+++ b/backend/app/schemas/series.py
@@ -48,3 +48,14 @@ class SeriesListResponse(BaseModel):
     total: int
     page: int
     per_page: int
+
+
+class PricingResponse(BaseModel):
+    free_episode_count: int
+    coin_cost_per_episode: int
+    model_config = {"from_attributes": True}
+
+
+class PricingUpdate(BaseModel):
+    free_episode_count: int | None = Field(None, ge=0)
+    coin_cost_per_episode: int | None = Field(None, ge=0)

--- a/backend/tests/test_monetization.py
+++ b/backend/tests/test_monetization.py
@@ -1,0 +1,250 @@
+"""Tests for monetization / pricing configuration."""
+
+import uuid
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+from tests.factories import make_episode, make_series
+
+
+@pytest.mark.asyncio
+async def test_series_has_pricing_fields(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Series response includes pricing fields."""
+    series = make_series(created_by=admin_user.id)
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.get(f"/api/series/{series.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert "free_episode_count" in data
+    assert "coin_cost_per_episode" in data
+
+
+@pytest.mark.asyncio
+async def test_default_free_episode_count_on_creation(
+    admin_client: httpx.AsyncClient,
+):
+    """Default free_episode_count is 3 when creating via API."""
+    response = await admin_client.post(
+        "/api/series",
+        json={"title": "Default Pricing Series"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["free_episode_count"] == 3
+    assert data["coin_cost_per_episode"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pricing_fields_with_custom_values(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Series detail includes custom pricing values."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=5,
+        coin_cost_per_episode=25,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.get(f"/api/series/{series.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["free_episode_count"] == 5
+    assert data["coin_cost_per_episode"] == 25
+
+
+@pytest.mark.asyncio
+async def test_get_pricing(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """GET /api/series/:id/pricing returns pricing."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=2,
+        coin_cost_per_episode=15,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.get(f"/api/series/{series.id}/pricing")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["free_episode_count"] == 2
+    assert data["coin_cost_per_episode"] == 15
+
+
+@pytest.mark.asyncio
+async def test_update_pricing(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """PATCH /api/series/:id/pricing updates pricing."""
+    series = make_series(created_by=admin_user.id)
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.patch(
+        f"/api/series/{series.id}/pricing",
+        json={"free_episode_count": 10, "coin_cost_per_episode": 50},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["free_episode_count"] == 10
+    assert data["coin_cost_per_episode"] == 50
+
+
+@pytest.mark.asyncio
+async def test_partial_pricing_update(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Partial pricing update leaves other field unchanged."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=5,
+        coin_cost_per_episode=20,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.patch(
+        f"/api/series/{series.id}/pricing",
+        json={"coin_cost_per_episode": 30},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["free_episode_count"] == 5  # unchanged
+    assert data["coin_cost_per_episode"] == 30
+
+
+@pytest.mark.asyncio
+async def test_negative_coin_cost_rejected(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Negative coin_cost_per_episode returns 422."""
+    series = make_series(created_by=admin_user.id)
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.patch(
+        f"/api/series/{series.id}/pricing",
+        json={"coin_cost_per_episode": -1},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_negative_free_episode_count_rejected(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Negative free_episode_count returns 422."""
+    series = make_series(created_by=admin_user.id)
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.patch(
+        f"/api/series/{series.id}/pricing",
+        json={"free_episode_count": -5},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_zero_free_episode_count_allowed(
+    admin_client: httpx.AsyncClient, db_session: AsyncSession, admin_user: User
+):
+    """Zero free_episode_count is valid (all episodes locked)."""
+    series = make_series(created_by=admin_user.id)
+    db_session.add(series)
+    await db_session.commit()
+
+    response = await admin_client.patch(
+        f"/api/series/{series.id}/pricing",
+        json={"free_episode_count": 0},
+    )
+    assert response.status_code == 200
+    assert response.json()["free_episode_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_episode_within_free_count(
+    db_session: AsyncSession, admin_user: User
+):
+    """Episode within free count is free (number <= free_episode_count)."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=3,
+        coin_cost_per_episode=10,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    ep = make_episode(series_id=series.id, created_by=admin_user.id, episode_number=1)
+    db_session.add(ep)
+    await db_session.commit()
+
+    # Business logic: episode_number <= free_episode_count means free
+    assert ep.episode_number <= series.free_episode_count
+
+
+@pytest.mark.asyncio
+async def test_episode_beyond_free_count(
+    db_session: AsyncSession, admin_user: User
+):
+    """Episode beyond free count is locked (number > free_episode_count)."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=3,
+        coin_cost_per_episode=10,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    ep = make_episode(series_id=series.id, created_by=admin_user.id, episode_number=4)
+    db_session.add(ep)
+    await db_session.commit()
+
+    assert ep.episode_number > series.free_episode_count
+
+
+@pytest.mark.asyncio
+async def test_boundary_episode_is_free(
+    db_session: AsyncSession, admin_user: User
+):
+    """Episode at boundary (number == free_episode_count) is free."""
+    series = make_series(
+        created_by=admin_user.id,
+        free_episode_count=3,
+        coin_cost_per_episode=10,
+    )
+    db_session.add(series)
+    await db_session.commit()
+
+    ep = make_episode(series_id=series.id, created_by=admin_user.id, episode_number=3)
+    db_session.add(ep)
+    await db_session.commit()
+
+    assert ep.episode_number <= series.free_episode_count
+
+
+@pytest.mark.asyncio
+async def test_pricing_endpoints_404_for_nonexistent_series(
+    admin_client: httpx.AsyncClient,
+):
+    """Pricing endpoints return 404 for non-existent series."""
+    fake_id = uuid.uuid4()
+
+    get_response = await admin_client.get(f"/api/series/{fake_id}/pricing")
+    assert get_response.status_code == 404
+
+    patch_response = await admin_client.patch(
+        f"/api/series/{fake_id}/pricing",
+        json={"free_episode_count": 5},
+    )
+    assert patch_response.status_code == 404

--- a/frontend/src/__tests__/components/EpisodeLockIndicator.spec.ts
+++ b/frontend/src/__tests__/components/EpisodeLockIndicator.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers'
+import SeriesDetailView from '../../views/SeriesDetailView.vue'
+
+// Mock the API module
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import api from '../../lib/api'
+
+describe('Episode Lock Indicators', () => {
+  const routes = [
+    { path: '/', name: 'dashboard', component: { template: '<div>Dashboard</div>' } },
+    { path: '/series', name: 'series', component: { template: '<div>Series</div>' } },
+    { path: '/series/:id', name: 'series-detail', component: SeriesDetailView },
+    { path: '/series/:id/edit', name: 'series-edit', component: { template: '<div>Edit</div>' } },
+    { path: '/series/:seriesId/episodes/create', name: 'episode-create', component: { template: '<div>Create</div>' } },
+    { path: '/series/:seriesId/episodes/:id/edit', name: 'episode-edit', component: { template: '<div>Edit Episode</div>' } },
+  ]
+
+  const authState = {
+    auth: {
+      accessToken: 'test-token',
+      refreshToken: 'test-refresh',
+      user: { id: 'u1', name: 'Admin', email: 'admin@test.com', role: 'admin', is_active: true },
+    },
+  }
+
+  function makeSeries(overrides = {}) {
+    return {
+      id: 's1',
+      title: 'Test Series',
+      description: 'A test series',
+      thumbnail_url: null,
+      status: 'published',
+      free_episode_count: 2,
+      coin_cost_per_episode: 10,
+      tags: [],
+      created_at: '2026-01-01T00:00:00Z',
+      ...overrides,
+    }
+  }
+
+  function makeEpisodes(episodes: Array<{ episode_number: number; title: string }>) {
+    return {
+      items: episodes.map((ep, i) => ({
+        id: `e${i + 1}`,
+        series_id: 's1',
+        title: ep.title,
+        description: null,
+        episode_number: ep.episode_number,
+        thumbnail_url: null,
+        status: 'published',
+        video_provider: null,
+        video_playback_id: null,
+        duration_seconds: null,
+        created_at: '2026-01-01T00:00:00Z',
+      })),
+      total: episodes.length,
+      page: 1,
+      per_page: 50,
+    }
+  }
+
+  function setupMocks(series: ReturnType<typeof makeSeries>, episodes: ReturnType<typeof makeEpisodes>) {
+    vi.mocked(api.get).mockImplementation((url) => {
+      if ((url as string).match(/\/api\/series\/[^/]+\/episodes/)) {
+        return Promise.resolve({ data: episodes })
+      }
+      if ((url as string).match(/\/api\/series\//)) {
+        return Promise.resolve({ data: series })
+      }
+      return Promise.reject(new Error('Unknown URL'))
+    })
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('free episode shows "Free" badge with green class', async () => {
+    const series = makeSeries({ free_episode_count: 2, coin_cost_per_episode: 10 })
+    const episodes = makeEpisodes([
+      { episode_number: 1, title: 'Ep 1' },
+      { episode_number: 2, title: 'Ep 2' },
+      { episode_number: 3, title: 'Ep 3' },
+    ])
+    setupMocks(series, episodes)
+
+    const wrapper = mountWithPlugins(SeriesDetailView, {
+      routes,
+      initialState: authState,
+    })
+    await wrapper.vm.$router.push('/series/s1')
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="episode-1-access"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('Free')
+    expect(badge.classes().join(' ')).toContain('bg-green-500/10')
+    expect(badge.classes().join(' ')).toContain('text-green-400')
+  })
+
+  it('locked episode shows coin cost badge with amber class', async () => {
+    const series = makeSeries({ free_episode_count: 2, coin_cost_per_episode: 10 })
+    const episodes = makeEpisodes([
+      { episode_number: 1, title: 'Ep 1' },
+      { episode_number: 2, title: 'Ep 2' },
+      { episode_number: 3, title: 'Ep 3' },
+    ])
+    setupMocks(series, episodes)
+
+    const wrapper = mountWithPlugins(SeriesDetailView, {
+      routes,
+      initialState: authState,
+    })
+    await wrapper.vm.$router.push('/series/s1')
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="episode-3-access"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('10 coins')
+    expect(badge.classes().join(' ')).toContain('bg-amber-500/10')
+    expect(badge.classes().join(' ')).toContain('text-amber-400')
+  })
+
+  it('boundary episode (number == free_count) shows "Free" badge', async () => {
+    const series = makeSeries({ free_episode_count: 2, coin_cost_per_episode: 10 })
+    const episodes = makeEpisodes([
+      { episode_number: 1, title: 'Ep 1' },
+      { episode_number: 2, title: 'Ep 2' },
+      { episode_number: 3, title: 'Ep 3' },
+    ])
+    setupMocks(series, episodes)
+
+    const wrapper = mountWithPlugins(SeriesDetailView, {
+      routes,
+      initialState: authState,
+    })
+    await wrapper.vm.$router.push('/series/s1')
+    await flushPromises()
+
+    const badge = wrapper.find('[data-testid="episode-2-access"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('Free')
+    expect(badge.classes().join(' ')).toContain('bg-green-500/10')
+  })
+})

--- a/frontend/src/__tests__/views/PricingConfig.spec.ts
+++ b/frontend/src/__tests__/views/PricingConfig.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mountWithPlugins } from '../helpers'
+import SeriesForm from '../../components/series/SeriesForm.vue'
+
+// Mock the API module
+vi.mock('../../lib/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import api from '../../lib/api'
+
+describe('PricingConfig', () => {
+  const mockTags = [
+    { id: 't1', name: 'Action', category: 'genre', created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    globalThis.FileReader = class {
+      onload: ((e: ProgressEvent<FileReader>) => void) | null = null
+      result: string = 'data:image/jpeg;base64,fake'
+      readAsDataURL = vi.fn()
+    } as unknown as typeof FileReader
+  })
+
+  it('renders pricing fields', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: mockTags })
+
+    const wrapper = mountWithPlugins(SeriesForm)
+    await flushPromises()
+
+    const freeEpisodesInput = wrapper.find('input#free-episodes')
+    expect(freeEpisodesInput.exists()).toBe(true)
+
+    const coinCostInput = wrapper.find('input#coin-cost')
+    expect(coinCostInput.exists()).toBe(true)
+  })
+
+  it('prefills pricing values in edit mode', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: mockTags })
+
+    const wrapper = mountWithPlugins(SeriesForm, {
+      props: {
+        initialData: {
+          title: 'Test',
+          free_episode_count: 7,
+          coin_cost_per_episode: 25,
+        },
+      },
+    })
+    await flushPromises()
+
+    const freeEpisodesInput = wrapper.find('input#free-episodes')
+    expect((freeEpisodesInput.element as HTMLInputElement).value).toBe('7')
+
+    const coinCostInput = wrapper.find('input#coin-cost')
+    expect((coinCostInput.element as HTMLInputElement).value).toBe('25')
+  })
+
+  it('submit includes pricing data in emitted event', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: mockTags })
+
+    const wrapper = mountWithPlugins(SeriesForm)
+    await flushPromises()
+
+    await wrapper.find('input#title').setValue('Priced Series')
+    await wrapper.find('input#free-episodes').setValue('4')
+    await wrapper.find('input#coin-cost').setValue('20')
+
+    await wrapper.find('form').trigger('submit')
+
+    const emitted = wrapper.emitted('submit')
+    expect(emitted).toBeDefined()
+    expect(emitted?.[0]?.[0]).toMatchObject({
+      free_episode_count: 4,
+      coin_cost_per_episode: 20,
+    })
+  })
+
+  it('inputs have min=0 validation', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: mockTags })
+
+    const wrapper = mountWithPlugins(SeriesForm)
+    await flushPromises()
+
+    const freeEpisodesInput = wrapper.find('input#free-episodes')
+    expect(freeEpisodesInput.attributes('min')).toBe('0')
+
+    const coinCostInput = wrapper.find('input#coin-cost')
+    expect(coinCostInput.attributes('min')).toBe('0')
+  })
+
+  it('shows pricing preview summary', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: mockTags })
+
+    const wrapper = mountWithPlugins(SeriesForm)
+    await flushPromises()
+
+    const preview = wrapper.find('[data-testid="pricing-preview"]')
+    expect(preview.exists()).toBe(true)
+
+    // Default values (0 free, 0 cost) → "All episodes are free"
+    expect(preview.text()).toBe('All episodes are free')
+
+    // Set free count and cost
+    await wrapper.find('input#free-episodes').setValue('3')
+    await wrapper.find('input#coin-cost').setValue('10')
+
+    expect(preview.text()).toBe('First 3 episodes free, then 10 coins each')
+  })
+})

--- a/frontend/src/components/series/SeriesForm.vue
+++ b/frontend/src/components/series/SeriesForm.vue
@@ -84,6 +84,15 @@ const tagsByCategory = computed(() => {
   return Object.entries(grouped).filter(([, items]) => items.length > 0)
 })
 
+const pricingPreview = computed(() => {
+  const free = freeEpisodeCount.value || 0
+  const cost = coinCostPerEpisode.value || 0
+  if (free === 0 && cost === 0) return 'All episodes are free'
+  if (free === 0) return `All episodes cost ${cost} coin${cost === 1 ? '' : 's'} each`
+  if (cost === 0) return `First ${free} episode${free === 1 ? '' : 's'} free, remaining episodes are free`
+  return `First ${free} episode${free === 1 ? '' : 's'} free, then ${cost} coin${cost === 1 ? '' : 's'} each`
+})
+
 // Initialize form with initial data
 function initializeForm() {
   if (props.initialData) {
@@ -394,6 +403,19 @@ onMounted(fetchTags)
           >
           <p class="mt-1 text-xs text-text-secondary">
             Cost in coins to unlock each premium episode
+          </p>
+        </div>
+
+        <!-- Pricing Preview -->
+        <div class="rounded-lg border border-border bg-bg-tertiary/50 px-4 py-3">
+          <p class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1">
+            Pricing Preview
+          </p>
+          <p
+            class="text-sm text-text-primary"
+            data-testid="pricing-preview"
+          >
+            {{ pricingPreview }}
           </p>
         </div>
       </div>

--- a/frontend/src/views/SeriesDetailView.vue
+++ b/frontend/src/views/SeriesDetailView.vue
@@ -160,6 +160,18 @@ function formatDuration(seconds: number | null): string {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
+function getEpisodePricingBadge(episodeNumber: number): { label: string; class: string } {
+  if (!series.value) return { label: '', class: '' }
+  if (episodeNumber <= series.value.free_episode_count) {
+    return { label: 'Free', class: 'bg-green-500/10 text-green-400' }
+  }
+  const cost = series.value.coin_cost_per_episode
+  return {
+    label: cost > 0 ? `${cost} coins` : 'Locked',
+    class: 'bg-amber-500/10 text-amber-400',
+  }
+}
+
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString('en-US', {
     year: 'numeric',
@@ -316,6 +328,9 @@ onMounted(() => {
                 Status
               </th>
               <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-24">
+                Access
+              </th>
+              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-24">
                 Duration
               </th>
               <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-32">
@@ -374,6 +389,14 @@ onMounted(() => {
                   ]"
                 >
                   {{ ep.status }}
+                </span>
+              </td>
+              <td class="px-4 py-3">
+                <span
+                  :class="[getEpisodePricingBadge(ep.episode_number).class, 'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium']"
+                  :data-testid="`episode-${ep.episode_number}-access`"
+                >
+                  {{ getEpisodePricingBadge(ep.episode_number).label }}
                 </span>
               </td>
               <td class="px-4 py-3 text-sm text-text-secondary font-mono">


### PR DESCRIPTION
## Summary
- **Pricing API endpoints**: `GET /api/series/:id/pricing` and `PATCH /api/series/:id/pricing` with `PricingResponse`/`PricingUpdate` schemas
- **Pricing preview**: Live computed summary in SeriesForm (e.g. "First 3 episodes free, then 10 coins each")
- **Episode access badges**: Free (green) / Locked (amber) indicators in the episode table on SeriesDetailView

Closes #40, #41, #42, #43, #59, #60

## Test Plan
- [x] 13 backend tests in `test_monetization.py` (pricing fields, endpoints, validation, boundary, 404)
- [x] 5 frontend tests in `PricingConfig.spec.ts` (fields, prefill, submit, min=0, preview text)
- [x] 3 frontend tests in `EpisodeLockIndicator.spec.ts` (free/locked/boundary badges)
- [x] Full suite: 100 backend tests, 53 frontend tests — all passing
- [x] `ruff check`, `vue-tsc --noEmit`, `eslint` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)