### PR TITLE
feat: light theme UI redesign matching reference designs

### DIFF
--- a/frontend/src/__tests__/components/EpisodeLockIndicator.spec.ts
+++ b/frontend/src/__tests__/components/EpisodeLockIndicator.spec.ts
@@ -104,8 +104,8 @@ describe('Episode Lock Indicators', () => {
     const badge = wrapper.find('[data-testid="episode-1-access"]')
     expect(badge.exists()).toBe(true)
     expect(badge.text()).toBe('Free')
-    expect(badge.classes().join(' ')).toContain('bg-green-500/10')
-    expect(badge.classes().join(' ')).toContain('text-green-400')
+    expect(badge.classes().join(' ')).toContain('bg-emerald-50')
+    expect(badge.classes().join(' ')).toContain('text-emerald-700')
   })
 
   it('locked episode shows coin cost badge with amber class', async () => {
@@ -127,8 +127,8 @@ describe('Episode Lock Indicators', () => {
     const badge = wrapper.find('[data-testid="episode-3-access"]')
     expect(badge.exists()).toBe(true)
     expect(badge.text()).toBe('10 coins')
-    expect(badge.classes().join(' ')).toContain('bg-amber-500/10')
-    expect(badge.classes().join(' ')).toContain('text-amber-400')
+    expect(badge.classes().join(' ')).toContain('bg-amber-50')
+    expect(badge.classes().join(' ')).toContain('text-amber-700')
   })
 
   it('boundary episode (number == free_count) shows "Free" badge', async () => {
@@ -150,6 +150,6 @@ describe('Episode Lock Indicators', () => {
     const badge = wrapper.find('[data-testid="episode-2-access"]')
     expect(badge.exists()).toBe(true)
     expect(badge.text()).toBe('Free')
-    expect(badge.classes().join(' ')).toContain('bg-green-500/10')
+    expect(badge.classes().join(' ')).toContain('bg-emerald-50')
   })
 })

--- a/frontend/src/__tests__/components/UiStates.spec.ts
+++ b/frontend/src/__tests__/components/UiStates.spec.ts
@@ -13,7 +13,7 @@ describe('LoadingSkeleton', () => {
     const wrapper = mount(LoadingSkeleton, {
       props: { variant: 'card', count: 2 },
     })
-    expect(wrapper.findAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(wrapper.findAll('.shimmer').length).toBeGreaterThan(0)
     // Should render 2 card skeletons
     expect(wrapper.findAll('.rounded-xl').length).toBe(2)
   })
@@ -22,14 +22,14 @@ describe('LoadingSkeleton', () => {
     const wrapper = mount(LoadingSkeleton, {
       props: { variant: 'row', count: 3 },
     })
-    expect(wrapper.findAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(wrapper.findAll('.shimmer').length).toBeGreaterThan(0)
   })
 
   it('renders text variant by default', () => {
     const wrapper = mount(LoadingSkeleton, {
       props: { count: 4 },
     })
-    expect(wrapper.findAll('.animate-pulse').length).toBeGreaterThan(0)
+    expect(wrapper.findAll('.shimmer').length).toBeGreaterThan(0)
   })
 })
 
@@ -39,7 +39,7 @@ describe('ErrorState', () => {
       props: { message: 'Something went wrong' },
     })
     expect(wrapper.text()).toContain('Something went wrong')
-    expect(wrapper.text()).toContain('Retry')
+    expect(wrapper.text()).toContain('Try again')
   })
 
   it('emits retry event on button click', async () => {

--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,26 +1,123 @@
 @import "tailwindcss";
 
-/* Saudi Green Dark Theme Tokens */
+/* Draama Light Theme Tokens */
 @theme {
   /* Background colors */
-  --color-bg-primary: #0A0A0A;
-  --color-bg-secondary: #171717;
-  --color-bg-tertiary: #262626;
+  --color-bg-primary: #F8F9FA;
+  --color-bg-secondary: #FFFFFF;
+  --color-bg-tertiary: #F9FAFB;
+
+  /* Sidebar colors */
+  --color-sidebar: #0F172A;
+  --color-sidebar-light: #1E293B;
 
   /* Accent colors */
   --color-accent: #006C35;
-  --color-accent-hover: #008542;
+  --color-accent-hover: #005a2c;
+  --color-accent-light: #E6F0EA;
 
   /* Text colors */
-  --color-text-primary: #FAFAFA;
-  --color-text-secondary: #A3A3A3;
+  --color-text-primary: #1F2937;
+  --color-text-secondary: #6B7280;
 
   /* UI colors */
-  --color-border: #404040;
+  --color-border: #E5E7EB;
   --color-destructive: #DC2626;
+
+  /* Extended palette */
+  --color-gold: #B8960C;
+  --color-gold-light: #F8F4E5;
+  --color-info: #3B82F6;
+  --color-info-light: #EFF6FF;
+  --color-warning: #F59E0B;
+  --color-warning-light: #FFFBEB;
+
+  /* Shadows */
+  --shadow-subtle: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-card: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --shadow-input: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-floating: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-dropdown: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 0 1px rgba(0,0,0,0.05);
 }
 
-/* Apply dark theme to body */
+/* Apply light theme to body */
 body {
   @apply bg-bg-primary text-text-primary;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
 }
+
+/* Glass header effect */
+.glass-header {
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid #E5E7EB;
+}
+
+/* Sidebar active item */
+.sidebar-item-active {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #FFFFFF;
+  border-left: 3px solid #006C35;
+}
+
+/* Sidebar hover */
+.sidebar-item:hover:not(.sidebar-item-active) {
+  background-color: rgba(255, 255, 255, 0.05);
+  color: #FFFFFF;
+}
+
+/* Loading shimmer animation */
+.shimmer {
+  background: #f6f7f8;
+  background-image: linear-gradient(to right, #f6f7f8 0%, #edeef1 20%, #f6f7f8 40%, #f6f7f8 100%);
+  background-repeat: no-repeat;
+  background-size: 800px 100%;
+  animation: placeholderShimmer 1.5s linear infinite;
+}
+
+@keyframes placeholderShimmer {
+  0% { background-position: -468px 0; }
+  100% { background-position: 468px 0; }
+}
+
+/* Form input focus style */
+.form-input:focus {
+  outline: none;
+  border-color: #006C35;
+  box-shadow: 0 0 0 3px rgba(0, 108, 53, 0.1);
+}
+
+/* Tag button styles */
+.tag-btn.selected {
+  background-color: #006C35;
+  color: white;
+  border-color: #006C35;
+}
+
+.tag-btn:not(.selected):hover {
+  background-color: #F3F4F6;
+  border-color: #D1D5DB;
+}
+
+/* Drag and drop zone active state */
+.drag-active {
+  border-color: #006C35;
+  background-color: #E6F0EA;
+}
+
+/* Badge pill style */
+.badge-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.625rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #CBD5E1; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #94A3B8; }

--- a/frontend/src/components/episodes/EpisodeForm.vue
+++ b/frontend/src/components/episodes/EpisodeForm.vue
@@ -272,104 +272,124 @@ onMounted(() => {
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <!-- Left column: Form fields -->
       <div class="space-y-6">
-        <!-- Title -->
-        <div>
-          <label
-            for="ep-title"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Title <span class="text-destructive">*</span>
-          </label>
-          <input
-            id="ep-title"
-            v-model="title"
-            type="text"
-            maxlength="255"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="Enter episode title"
-          >
-          <p
-            v-if="titleError"
-            class="mt-1 text-sm text-destructive"
-          >
-            {{ titleError }}
-          </p>
-        </div>
+        <!-- Basic Info Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6 space-y-5">
+          <!-- Title -->
+          <div>
+            <label
+              for="ep-title"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Title <span class="text-destructive">*</span>
+            </label>
+            <input
+              id="ep-title"
+              v-model="title"
+              type="text"
+              maxlength="255"
+              class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors"
+              placeholder="Enter episode title"
+            >
+            <p
+              v-if="titleError"
+              class="mt-1 text-sm text-destructive"
+            >
+              {{ titleError }}
+            </p>
+          </div>
 
-        <!-- Description -->
-        <div>
-          <label
-            for="ep-description"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Description
-          </label>
-          <textarea
-            id="ep-description"
-            v-model="description"
-            rows="4"
-            maxlength="2000"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent resize-none"
-            placeholder="Enter episode description"
-          />
-          <p class="mt-1 text-xs text-text-secondary">
-            {{ description.length }}/2000 characters
-          </p>
-        </div>
+          <!-- Description -->
+          <div>
+            <label
+              for="ep-description"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="ep-description"
+              v-model="description"
+              rows="4"
+              maxlength="2000"
+              class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors resize-none"
+              placeholder="Enter episode description"
+            />
+            <p class="mt-1 text-xs text-gray-500">
+              {{ description.length }}/2000 characters
+            </p>
+          </div>
 
-        <!-- Episode Number -->
-        <div>
-          <label
-            for="ep-number"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Episode Number
-          </label>
-          <input
-            id="ep-number"
-            v-model.number="episodeNumber"
-            type="number"
-            min="1"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="Auto-assigned if empty"
-          >
-          <p class="mt-1 text-xs text-text-secondary">
-            Leave empty to auto-assign the next number
-          </p>
-        </div>
+          <!-- Episode Number -->
+          <div>
+            <label
+              for="ep-number"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Episode Number
+            </label>
+            <input
+              id="ep-number"
+              v-model.number="episodeNumber"
+              type="number"
+              min="1"
+              class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors"
+              placeholder="Auto-assigned if empty"
+            >
+            <p class="mt-1 text-xs text-gray-500">
+              Leave empty to auto-assign the next number
+            </p>
+          </div>
 
-        <!-- Status -->
-        <div>
-          <label
-            for="ep-status"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Status
-          </label>
-          <select
-            id="ep-status"
-            v-model="status"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-          >
-            <option value="draft">
-              Draft
-            </option>
-            <option value="published">
-              Published
-            </option>
-          </select>
+          <!-- Status -->
+          <div>
+            <label
+              for="ep-status"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Status
+            </label>
+            <div class="relative">
+              <select
+                id="ep-status"
+                v-model="status"
+                class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 bg-white appearance-none transition-colors"
+              >
+                <option value="draft">
+                  Draft
+                </option>
+                <option value="published">
+                  Published
+                </option>
+              </select>
+              <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                <svg
+                  class="h-4 w-4 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
 
       <!-- Right column: Thumbnail + Video Upload -->
       <div class="space-y-6">
-        <!-- Thumbnail Upload -->
-        <div>
-          <label class="block text-sm font-medium text-text-secondary mb-1">
+        <!-- Thumbnail Upload Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6">
+          <label class="block text-sm font-medium text-gray-700 mb-2">
             Thumbnail
           </label>
           <div
-            class="relative w-full aspect-video rounded-lg border-2 border-dashed border-border hover:border-accent transition-colors cursor-pointer overflow-hidden bg-bg-tertiary"
+            class="relative w-full aspect-video rounded-lg border-2 border-dashed border-gray-300 hover:border-accent transition-colors cursor-pointer overflow-hidden bg-gray-50"
             @click="fileInput?.click()"
           >
             <div
@@ -389,7 +409,7 @@ onMounted(() => {
                   <div class="text-white text-sm mb-2">
                     Uploading...
                   </div>
-                  <div class="w-48 bg-bg-tertiary rounded-full h-2">
+                  <div class="w-48 bg-white/20 rounded-full h-2">
                     <div
                       class="bg-accent h-2 rounded-full transition-all"
                       :style="{ width: `${thumbnailUploadProgress}%` }"
@@ -402,11 +422,11 @@ onMounted(() => {
               v-else
               class="absolute inset-0 flex flex-col items-center justify-center"
             >
-              <PhotoIcon class="h-12 w-12 text-text-secondary mb-2" />
-              <p class="text-sm text-text-secondary">
+              <PhotoIcon class="h-12 w-12 text-gray-400 mb-2" />
+              <p class="text-sm text-gray-500">
                 Click to upload thumbnail
               </p>
-              <p class="text-xs text-text-secondary mt-1">
+              <p class="text-xs text-gray-400 mt-1">
                 Max 5MB, image files only
               </p>
             </div>
@@ -427,9 +447,12 @@ onMounted(() => {
           </p>
         </div>
 
-        <!-- Video Upload (only in edit mode) -->
-        <div v-if="isEditMode">
-          <label class="block text-sm font-medium text-text-secondary mb-1">
+        <!-- Video Upload Card (only in edit mode) -->
+        <div
+          v-if="isEditMode"
+          class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6"
+        >
+          <label class="block text-sm font-medium text-gray-700 mb-2">
             Video
           </label>
 
@@ -441,7 +464,7 @@ onMounted(() => {
             />
             <button
               type="button"
-              class="mt-3 w-full flex items-center justify-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+              class="mt-3 w-full flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               @click="isReplacingVideo = true"
             >
               <ArrowPathIcon class="h-4 w-4" />
@@ -452,20 +475,20 @@ onMounted(() => {
           <!-- Video file selection area -->
           <template v-else>
             <div
-              class="relative w-full rounded-lg border-2 border-dashed border-border hover:border-accent transition-colors cursor-pointer overflow-hidden bg-bg-tertiary p-6"
+              class="relative w-full rounded-lg border-2 border-dashed border-gray-300 hover:border-accent transition-colors cursor-pointer overflow-hidden bg-gray-50 p-6"
               @click="videoFileInput?.click()"
             >
               <div class="flex flex-col items-center justify-center text-center">
                 <!-- Upload success -->
                 <div
                   v-if="videoUploadSuccess"
-                  class="text-green-400"
+                  class="text-accent"
                 >
                   <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2" />
                   <p class="text-sm font-medium">
                     Video uploaded successfully
                   </p>
-                  <p class="text-xs text-text-secondary mt-1">
+                  <p class="text-xs text-gray-500 mt-1">
                     Processing may take a few minutes
                   </p>
                 </div>
@@ -476,38 +499,38 @@ onMounted(() => {
                   class="w-full"
                 >
                   <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2 text-accent animate-pulse" />
-                  <p class="text-sm text-text-primary mb-3">
+                  <p class="text-sm text-gray-900 mb-3">
                     Uploading video...
                   </p>
-                  <div class="w-full bg-bg-primary rounded-full h-3 mb-2">
+                  <div class="w-full bg-gray-200 rounded-full h-3 mb-2">
                     <div
                       class="bg-accent h-3 rounded-full transition-all duration-300"
                       :style="{ width: `${videoUploadProgress}%` }"
                     />
                   </div>
-                  <p class="text-xs text-text-secondary">
+                  <p class="text-xs text-gray-500">
                     {{ videoUploadProgress }}% complete
                   </p>
                 </div>
 
                 <!-- File selected, ready to upload -->
                 <div v-else-if="videoFile">
-                  <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2 text-text-secondary" />
-                  <p class="text-sm font-medium text-text-primary">
+                  <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2 text-gray-400" />
+                  <p class="text-sm font-medium text-gray-900">
                     {{ videoFileName }}
                   </p>
-                  <p class="text-xs text-text-secondary mt-1">
+                  <p class="text-xs text-gray-500 mt-1">
                     {{ formatFileSize(videoFile.size) }}
                   </p>
                 </div>
 
                 <!-- Empty state -->
                 <div v-else>
-                  <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2 text-text-secondary" />
-                  <p class="text-sm text-text-secondary">
+                  <CloudArrowUpIcon class="h-10 w-10 mx-auto mb-2 text-gray-400" />
+                  <p class="text-sm text-gray-500">
                     Click to select a video file
                   </p>
-                  <p class="text-xs text-text-secondary mt-1">
+                  <p class="text-xs text-gray-400 mt-1">
                     Max 2GB, video files only
                   </p>
                 </div>
@@ -537,7 +560,7 @@ onMounted(() => {
             <button
               v-if="videoPlaybackId && isReplacingVideo && !videoUploadLoading && !videoUploadSuccess"
               type="button"
-              class="mt-2 w-full text-center text-sm text-text-secondary hover:text-text-primary transition-colors"
+              class="mt-2 w-full text-center text-sm text-gray-500 hover:text-gray-700 transition-colors"
               @click="isReplacingVideo = false; videoFile = null; videoFileName = ''"
             >
               Cancel replacement
@@ -555,9 +578,9 @@ onMounted(() => {
         <!-- Info note for create mode -->
         <div
           v-else
-          class="rounded-lg bg-bg-tertiary/50 border border-border/50 p-4"
+          class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-4"
         >
-          <p class="text-sm text-text-secondary">
+          <p class="text-sm text-gray-500">
             Video upload will be available after creating the episode.
           </p>
         </div>
@@ -577,10 +600,10 @@ onMounted(() => {
     </div>
 
     <!-- Form Actions -->
-    <div class="flex justify-end gap-3 mt-8 pt-6 border-t border-border">
+    <div class="sticky bottom-0 bg-white border-t border-gray-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] -mx-6 px-6 py-4 mt-8 flex justify-end gap-3">
       <button
         type="button"
-        class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+        class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
         @click="emit('cancel')"
       >
         Cancel

--- a/frontend/src/components/layout/AppLayout.vue
+++ b/frontend/src/components/layout/AppLayout.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { Bars3Icon } from '@heroicons/vue/24/outline'
+import {
+  Bars3Icon,
+  BellIcon,
+  GlobeAltIcon,
+  ChevronDownIcon,
+} from '@heroicons/vue/24/outline'
 import Sidebar from './Sidebar.vue'
 import GlobalSearch from './GlobalSearch.vue'
 
@@ -18,23 +23,43 @@ const publicRoutes = ['login', 'auth-callback']
         :mobile-open="sidebarOpen"
         @close="sidebarOpen = false"
       />
-      <main class="lg:pl-64">
-        <!-- Top Bar -->
-        <div class="flex items-center justify-between px-4 sm:px-8 py-4 border-b border-border">
-          <button
-            class="lg:hidden text-text-secondary hover:text-text-primary transition-colors"
-            @click="sidebarOpen = true"
-          >
-            <Bars3Icon class="h-6 w-6" />
-          </button>
-          <div class="flex-1" />
-          <GlobalSearch />
-        </div>
+      <div class="lg:pl-64 flex flex-col min-h-screen">
+        <!-- Top Bar - Glass Header -->
+        <header class="glass-header sticky top-0 z-30 h-16 px-4 sm:px-6 lg:px-8 flex items-center justify-between gap-4">
+          <div class="flex items-center gap-4 flex-1">
+            <button
+              class="lg:hidden p-2 text-gray-500 hover:text-accent transition-colors rounded-md hover:bg-gray-100"
+              @click="sidebarOpen = true"
+            >
+              <Bars3Icon class="h-6 w-6" />
+            </button>
+            <GlobalSearch />
+          </div>
+
+          <div class="flex items-center gap-3 sm:gap-4 shrink-0">
+            <!-- Notification Bell -->
+            <button class="p-2 text-gray-400 hover:text-text-primary transition-colors relative">
+              <BellIcon class="h-5 w-5" />
+              <span class="absolute top-1.5 right-1.5 w-2 h-2 bg-destructive rounded-full border-2 border-white" />
+            </button>
+
+            <!-- Separator -->
+            <div class="h-6 w-px bg-gray-200 mx-1" />
+
+            <!-- Language Switcher -->
+            <button class="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-accent transition-colors">
+              <GlobeAltIcon class="h-4 w-4 text-gray-400" />
+              <span>EN</span>
+              <ChevronDownIcon class="h-3 w-3 text-gray-400" />
+            </button>
+          </div>
+        </header>
+
         <!-- Page Content -->
-        <div class="px-4 sm:px-8 py-6">
+        <main class="flex-1 px-4 sm:px-6 lg:px-8 py-6">
           <slot />
-        </div>
-      </main>
+        </main>
+      </div>
     </template>
     <template v-else>
       <slot />

--- a/frontend/src/components/layout/GlobalSearch.vue
+++ b/frontend/src/components/layout/GlobalSearch.vue
@@ -143,26 +143,29 @@ onUnmounted(() => {
 <template>
   <div
     ref="dropdownRef"
-    class="relative"
+    class="hidden md:block relative max-w-md w-64 lg:w-96"
   >
     <!-- Search Input -->
     <div class="relative">
-      <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-secondary" />
+      <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
       <input
         ref="inputRef"
         v-model="query"
         type="text"
-        placeholder="Search… Ctrl+K"
-        class="w-64 rounded-lg border border-border bg-bg-tertiary pl-9 pr-3 py-1.5 text-sm text-text-primary placeholder-text-secondary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent transition-colors"
+        placeholder="Search series, users, or tags..."
+        class="block w-full pl-10 pr-16 py-2 border border-border rounded-lg leading-5 bg-white placeholder-gray-400 text-text-primary focus:outline-none focus:ring-1 focus:ring-accent focus:border-accent text-sm shadow-[--shadow-subtle] transition-all"
         @keydown="handleKeydown"
         @focus="() => { if (results.length > 0) isOpen = true }"
       >
+      <div class="absolute inset-y-0 right-0 pr-2 flex items-center">
+        <span class="text-gray-400 text-xs border border-gray-200 rounded px-1.5 py-0.5">Ctrl+K</span>
+      </div>
     </div>
 
     <!-- Results Dropdown -->
     <div
       v-if="isOpen"
-      class="absolute right-0 top-full mt-2 w-96 rounded-xl border border-border bg-bg-secondary shadow-2xl shadow-black/30 overflow-hidden z-50"
+      class="absolute left-0 top-full mt-2 w-96 rounded-xl border border-border bg-white shadow-[--shadow-dropdown] overflow-hidden z-50"
     >
       <!-- Loading -->
       <div
@@ -186,34 +189,34 @@ onUnmounted(() => {
       <template v-else>
         <!-- Series Group -->
         <div v-if="seriesResults.length > 0">
-          <div class="px-3 py-2 text-xs font-medium text-text-secondary uppercase tracking-wider bg-bg-primary/50">
+          <div class="px-3 py-2 text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50/80">
             Series
           </div>
           <button
             v-for="(item, i) in seriesResults"
             :key="item.id"
             :class="[
-              activeIndex === i ? 'bg-accent/10' : 'hover:bg-bg-tertiary/50',
+              activeIndex === i ? 'bg-accent/5' : 'hover:bg-gray-50',
               'flex items-center gap-3 w-full px-3 py-2.5 text-left transition-colors',
             ]"
             @click="navigateToResult(item)"
             @mouseenter="activeIndex = i"
           >
-            <FilmIcon class="h-4 w-4 text-text-secondary flex-shrink-0" />
+            <FilmIcon class="h-4 w-4 text-gray-400 flex-shrink-0" />
             <div class="min-w-0 flex-1">
-              <p class="text-sm font-medium text-text-primary truncate">
+              <p class="text-sm font-medium text-gray-900 truncate">
                 {{ item.title }}
               </p>
               <p
                 v-if="item.description"
-                class="text-xs text-text-secondary truncate"
+                class="text-xs text-gray-500 truncate"
               >
                 {{ item.description }}
               </p>
             </div>
             <span
               v-if="item.status"
-              class="text-xs text-text-secondary capitalize flex-shrink-0"
+              class="text-xs text-gray-500 capitalize flex-shrink-0"
             >
               {{ item.status }}
             </span>
@@ -222,25 +225,25 @@ onUnmounted(() => {
 
         <!-- Episodes Group -->
         <div v-if="episodeResults.length > 0">
-          <div class="px-3 py-2 text-xs font-medium text-text-secondary uppercase tracking-wider bg-bg-primary/50">
+          <div class="px-3 py-2 text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-50/80">
             Episodes
           </div>
           <button
             v-for="(item, j) in episodeResults"
             :key="item.id"
             :class="[
-              activeIndex === seriesResults.length + j ? 'bg-accent/10' : 'hover:bg-bg-tertiary/50',
+              activeIndex === seriesResults.length + j ? 'bg-accent/5' : 'hover:bg-gray-50',
               'flex items-center gap-3 w-full px-3 py-2.5 text-left transition-colors',
             ]"
             @click="navigateToResult(item)"
             @mouseenter="activeIndex = seriesResults.length + j"
           >
-            <PlayCircleIcon class="h-4 w-4 text-text-secondary flex-shrink-0" />
+            <PlayCircleIcon class="h-4 w-4 text-gray-400 flex-shrink-0" />
             <div class="min-w-0 flex-1">
-              <p class="text-sm font-medium text-text-primary truncate">
+              <p class="text-sm font-medium text-gray-900 truncate">
                 {{ item.title }}
               </p>
-              <p class="text-xs text-text-secondary truncate">
+              <p class="text-xs text-gray-500 truncate">
                 {{ item.series_title }} · Episode {{ item.episode_number }}
               </p>
             </div>

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -5,9 +5,10 @@ import {
   FilmIcon,
   Cog6ToothIcon,
   UsersIcon,
-  ArrowRightStartOnRectangleIcon,
   TagIcon,
   XMarkIcon,
+  ChevronRightIcon,
+  PlayIcon,
 } from '@heroicons/vue/24/outline'
 import { useAuthStore } from '../../stores/auth'
 
@@ -23,16 +24,49 @@ const emit = defineEmits<{
   close: []
 }>()
 
-const navigation = [
-  { name: 'Dashboard', href: '/', icon: HomeIcon },
-  { name: 'Series', href: '/series', icon: FilmIcon },
-  { name: 'Tags', href: '/tags', icon: TagIcon },
-  { name: 'Users', href: '/users', icon: UsersIcon, adminOnly: true },
-  { name: 'Settings', href: '/settings', icon: Cog6ToothIcon },
+interface NavItem {
+  name: string
+  href: string
+  icon: typeof HomeIcon
+  adminOnly?: boolean
+}
+
+interface NavSection {
+  label: string
+  items: NavItem[]
+}
+
+const sections: NavSection[] = [
+  {
+    label: 'Overview',
+    items: [
+      { name: 'Dashboard', href: '/', icon: HomeIcon },
+    ],
+  },
+  {
+    label: 'Content',
+    items: [
+      { name: 'Series', href: '/series', icon: FilmIcon },
+      { name: 'Tags & Genres', href: '/tags', icon: TagIcon },
+    ],
+  },
+  {
+    label: 'Users',
+    items: [
+      { name: 'Users', href: '/users', icon: UsersIcon, adminOnly: true },
+    ],
+  },
+  {
+    label: 'System',
+    items: [
+      { name: 'Settings', href: '/settings', icon: Cog6ToothIcon },
+    ],
+  },
 ]
 
 function isActive(href: string): boolean {
-  return route.path === href
+  if (href === '/') return route.path === '/'
+  return route.path.startsWith(href)
 }
 
 function handleLogout() {
@@ -43,27 +77,42 @@ function handleLogout() {
 function handleNavClick() {
   emit('close')
 }
+
+function getUserInitials(): string {
+  const name = auth.user?.name ?? ''
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
 </script>
 
 <template>
   <!-- Mobile overlay -->
   <div
     v-if="mobileOpen"
-    class="fixed inset-0 z-40 bg-black/50 lg:hidden"
+    class="fixed inset-0 z-40 bg-gray-900/50 lg:hidden"
     @click="emit('close')"
   />
 
   <aside
     :class="[
-      'fixed inset-y-0 left-0 z-50 w-64 bg-bg-secondary border-r border-bg-tertiary flex flex-col transition-transform duration-200',
+      'fixed inset-y-0 left-0 z-50 w-64 bg-sidebar text-slate-400 flex flex-col transition-transform duration-200 shadow-xl lg:shadow-none',
       mobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
     ]"
   >
     <!-- Logo -->
-    <div class="flex h-16 items-center justify-between px-6 border-b border-bg-tertiary">
-      <span class="text-xl font-bold text-accent">nDrama</span>
+    <div class="flex h-16 items-center justify-between px-6 border-b border-white/10 shrink-0">
+      <div class="flex items-center gap-3 text-white">
+        <div class="w-8 h-8 bg-accent rounded-md flex items-center justify-center shadow-lg">
+          <PlayIcon class="h-3.5 w-3.5 text-white" />
+        </div>
+        <span class="text-xl font-bold tracking-tight">Draama</span>
+      </div>
       <button
-        class="lg:hidden text-text-secondary hover:text-text-primary transition-colors"
+        class="lg:hidden text-slate-400 hover:text-white transition-colors"
         @click="emit('close')"
       >
         <XMarkIcon class="h-5 w-5" />
@@ -71,10 +120,22 @@ function handleNavClick() {
     </div>
 
     <!-- Navigation -->
-    <nav class="mt-6 px-3 flex-1">
-      <ul class="space-y-1">
-        <li
-          v-for="item in navigation"
+    <nav class="flex-1 overflow-y-auto py-6 px-3 space-y-1">
+      <template
+        v-for="(section, sIdx) in sections"
+        :key="section.label"
+      >
+        <p
+          :class="[
+            'px-3 text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2',
+            sIdx > 0 ? 'mt-8' : '',
+          ]"
+        >
+          {{ section.label }}
+        </p>
+
+        <template
+          v-for="item in section.items"
           :key="item.name"
         >
           <RouterLink
@@ -82,44 +143,45 @@ function handleNavClick() {
             :to="item.href"
             :class="[
               isActive(item.href)
-                ? 'bg-accent text-white'
-                : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
-              'group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                ? 'sidebar-item-active'
+                : 'sidebar-item',
+              'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all',
             ]"
             @click="handleNavClick"
           >
             <component
               :is="item.icon"
               :class="[
-                isActive(item.href) ? 'text-white' : 'text-text-secondary group-hover:text-text-primary',
+                isActive(item.href) ? 'text-white' : 'text-slate-400',
                 'h-5 w-5 shrink-0 transition-colors',
               ]"
             />
             {{ item.name }}
           </RouterLink>
-        </li>
-      </ul>
+        </template>
+      </template>
     </nav>
 
     <!-- User section at bottom -->
-    <div class="border-t border-bg-tertiary p-3">
-      <div class="flex items-center gap-3 px-3 py-2">
-        <div class="flex-1 min-w-0">
-          <p class="text-sm font-medium text-text-primary truncate">
+    <div class="p-4 border-t border-white/10 shrink-0">
+      <button
+        class="flex items-center gap-3 w-full p-2 rounded-lg hover:bg-white/5 transition-colors cursor-pointer group"
+        title="Sign out"
+        @click="handleLogout"
+      >
+        <div class="w-9 h-9 rounded-full bg-slate-700 flex items-center justify-center border border-white/20 text-sm font-medium text-white">
+          {{ getUserInitials() }}
+        </div>
+        <div class="flex-1 min-w-0 text-left">
+          <p class="text-sm font-medium text-white truncate">
             {{ auth.user?.name }}
           </p>
-          <p class="text-xs text-text-secondary truncate">
+          <p class="text-xs text-slate-500 truncate group-hover:text-slate-400">
             {{ auth.user?.email }}
           </p>
         </div>
-        <button
-          class="text-text-secondary hover:text-text-primary transition-colors"
-          title="Sign out"
-          @click="handleLogout"
-        >
-          <ArrowRightStartOnRectangleIcon class="h-5 w-5" />
-        </button>
-      </div>
+        <ChevronRightIcon class="h-4 w-4 text-slate-600 group-hover:text-white transition-colors shrink-0" />
+      </button>
     </div>
   </aside>
 </template>

--- a/frontend/src/components/series/SeriesForm.vue
+++ b/frontend/src/components/series/SeriesForm.vue
@@ -265,27 +265,6 @@ function getCategoryDisplayName(category: string): string {
   }
 }
 
-// Get tag chip classes
-function getTagChipClass(tagId: string, category: string | null): string {
-  const isSelected = selectedTagIds.value.has(tagId)
-  const baseClasses = 'inline-flex items-center rounded-full px-3 py-1 text-xs font-medium cursor-pointer transition-all'
-
-  if (isSelected) {
-    return `${baseClasses} bg-accent text-white hover:bg-accent-hover`
-  }
-
-  switch (category) {
-    case 'genre':
-      return `${baseClasses} bg-blue-500/15 text-blue-400 hover:bg-blue-500/25`
-    case 'mood':
-      return `${baseClasses} bg-purple-500/15 text-purple-400 hover:bg-purple-500/25`
-    case 'language':
-      return `${baseClasses} bg-green-500/15 text-green-400 hover:bg-green-500/25`
-    default:
-      return `${baseClasses} bg-bg-tertiary text-text-secondary hover:bg-bg-tertiary/70`
-  }
-}
-
 onMounted(fetchTags)
 </script>
 
@@ -294,141 +273,187 @@ onMounted(fetchTags)
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <!-- Left column: Form fields -->
       <div class="space-y-6">
-        <!-- Title -->
-        <div>
-          <label
-            for="title"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Title <span class="text-destructive">*</span>
-          </label>
-          <input
-            id="title"
-            v-model="title"
-            type="text"
-            maxlength="255"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="Enter series title"
-          >
-          <p
-            v-if="titleError"
-            class="mt-1 text-sm text-destructive"
-          >
-            {{ titleError }}
-          </p>
+        <!-- Basic Info Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6 space-y-5">
+          <!-- Title -->
+          <div>
+            <label
+              for="title"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Title <span class="text-destructive">*</span>
+            </label>
+            <input
+              id="title"
+              v-model="title"
+              type="text"
+              maxlength="255"
+              class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors"
+              placeholder="Enter series title"
+            >
+            <p
+              v-if="titleError"
+              class="mt-1 text-sm text-destructive"
+            >
+              {{ titleError }}
+            </p>
+          </div>
+
+          <!-- Description -->
+          <div>
+            <label
+              for="description"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Description
+            </label>
+            <textarea
+              id="description"
+              v-model="description"
+              rows="4"
+              maxlength="2000"
+              class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors resize-none"
+              placeholder="Enter series description"
+            />
+            <p class="mt-1 text-xs text-gray-500">
+              {{ description.length }}/2000 characters
+            </p>
+          </div>
+
+          <!-- Status -->
+          <div>
+            <label
+              for="status"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Status
+            </label>
+            <div class="relative">
+              <select
+                id="status"
+                v-model="status"
+                class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 bg-white appearance-none transition-colors"
+              >
+                <option value="draft">
+                  Draft
+                </option>
+                <option value="published">
+                  Published
+                </option>
+                <option value="archived">
+                  Archived
+                </option>
+              </select>
+              <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                <svg
+                  class="h-4 w-4 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <!-- Description -->
-        <div>
-          <label
-            for="description"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Description
-          </label>
-          <textarea
-            id="description"
-            v-model="description"
-            rows="4"
-            maxlength="2000"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent resize-none"
-            placeholder="Enter series description"
-          />
-          <p class="mt-1 text-xs text-text-secondary">
-            {{ description.length }}/2000 characters
-          </p>
-        </div>
+        <!-- Monetization Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6">
+          <!-- Monetization Header -->
+          <div class="flex items-center gap-3 mb-5">
+            <div class="flex items-center justify-center w-10 h-10 rounded-full bg-gold-light">
+              <svg
+                class="w-5 h-5 text-gold"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.736 6.979C9.208 6.193 9.696 6 10 6c.304 0 .792.193 1.264.979a1 1 0 001.715-1.029C12.279 4.784 11.232 4 10 4s-2.279.784-2.979 1.95c-.285.475-.507 1-.67 1.55H6a1 1 0 000 2h.013a9.358 9.358 0 000 1H6a1 1 0 100 2h.351c.163.55.385 1.075.67 1.55C7.721 15.216 8.768 16 10 16s2.279-.784 2.979-1.95a1 1 0 10-1.715-1.029c-.472.786-.96.979-1.264.979-.304 0-.792-.193-1.264-.979a5.389 5.389 0 01-.421-.821H10a1 1 0 100-2H8.014a7.467 7.467 0 010-1H10a1 1 0 100-2H8.315c.12-.29.264-.562.421-.821z" />
+              </svg>
+            </div>
+            <div>
+              <h3 class="text-base font-semibold text-gray-900">
+                Monetization
+              </h3>
+              <p class="text-xs text-gray-500">
+                Configure pricing for this series
+              </p>
+            </div>
+          </div>
 
-        <!-- Status -->
-        <div>
-          <label
-            for="status"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Status
-          </label>
-          <select
-            id="status"
-            v-model="status"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-          >
-            <option value="draft">
-              Draft
-            </option>
-            <option value="published">
-              Published
-            </option>
-            <option value="archived">
-              Archived
-            </option>
-          </select>
-        </div>
+          <div class="grid grid-cols-2 gap-4">
+            <!-- Free Episode Count -->
+            <div>
+              <label
+                for="free-episodes"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Free Episodes
+              </label>
+              <input
+                id="free-episodes"
+                v-model.number="freeEpisodeCount"
+                type="number"
+                min="0"
+                class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors"
+                placeholder="0"
+              >
+              <p class="mt-1 text-xs text-gray-500">
+                Episodes available for free
+              </p>
+            </div>
 
-        <!-- Free Episode Count -->
-        <div>
-          <label
-            for="free-episodes"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Free Episode Count
-          </label>
-          <input
-            id="free-episodes"
-            v-model.number="freeEpisodeCount"
-            type="number"
-            min="0"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="0"
-          >
-          <p class="mt-1 text-xs text-text-secondary">
-            Number of episodes available for free
-          </p>
-        </div>
+            <!-- Coin Cost Per Episode -->
+            <div>
+              <label
+                for="coin-cost"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Coin Cost
+              </label>
+              <input
+                id="coin-cost"
+                v-model.number="coinCostPerEpisode"
+                type="number"
+                min="0"
+                class="form-input block w-full rounded-lg border-gray-300 shadow-[--shadow-input] sm:text-sm py-2.5 px-3 text-gray-900 placeholder-gray-400 transition-colors"
+                placeholder="0"
+              >
+              <p class="mt-1 text-xs text-gray-500">
+                Coins per premium episode
+              </p>
+            </div>
+          </div>
 
-        <!-- Coin Cost Per Episode -->
-        <div>
-          <label
-            for="coin-cost"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Coin Cost Per Episode
-          </label>
-          <input
-            id="coin-cost"
-            v-model.number="coinCostPerEpisode"
-            type="number"
-            min="0"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="0"
-          >
-          <p class="mt-1 text-xs text-text-secondary">
-            Cost in coins to unlock each premium episode
-          </p>
-        </div>
-
-        <!-- Pricing Preview -->
-        <div class="rounded-lg border border-border bg-bg-tertiary/50 px-4 py-3">
-          <p class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1">
-            Pricing Preview
-          </p>
-          <p
-            class="text-sm text-text-primary"
-            data-testid="pricing-preview"
-          >
-            {{ pricingPreview }}
-          </p>
+          <!-- Pricing Preview -->
+          <div class="mt-4 rounded-lg bg-accent-light border-l-4 border-accent px-4 py-3">
+            <p class="text-xs font-medium text-accent uppercase tracking-wider mb-1">
+              Pricing Preview
+            </p>
+            <p
+              class="text-sm font-medium text-accent"
+              data-testid="pricing-preview"
+            >
+              {{ pricingPreview }}
+            </p>
+          </div>
         </div>
       </div>
 
       <!-- Right column: Thumbnail and Tags -->
       <div class="space-y-6">
-        <!-- Thumbnail Upload -->
-        <div>
-          <label class="block text-sm font-medium text-text-secondary mb-1">
+        <!-- Thumbnail Upload Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6">
+          <label class="block text-sm font-medium text-gray-700 mb-2">
             Thumbnail
           </label>
           <div
-            class="relative w-full aspect-video rounded-lg border-2 border-dashed border-border hover:border-accent transition-colors cursor-pointer overflow-hidden bg-bg-tertiary"
+            class="relative w-full aspect-video rounded-lg border-2 border-dashed border-gray-300 hover:border-accent transition-colors cursor-pointer overflow-hidden bg-gray-50"
             @click="fileInput?.click()"
           >
             <!-- Preview -->
@@ -450,7 +475,7 @@ onMounted(fetchTags)
                   <div class="text-white text-sm mb-2">
                     Uploading...
                   </div>
-                  <div class="w-48 bg-bg-tertiary rounded-full h-2">
+                  <div class="w-48 bg-white/20 rounded-full h-2">
                     <div
                       class="bg-accent h-2 rounded-full transition-all"
                       :style="{ width: `${uploadProgress}%` }"
@@ -465,11 +490,11 @@ onMounted(fetchTags)
               v-else
               class="absolute inset-0 flex flex-col items-center justify-center"
             >
-              <PhotoIcon class="h-12 w-12 text-text-secondary mb-2" />
-              <p class="text-sm text-text-secondary">
+              <PhotoIcon class="h-12 w-12 text-gray-400 mb-2" />
+              <p class="text-sm text-gray-500">
                 Click to upload thumbnail
               </p>
-              <p class="text-xs text-text-secondary mt-1">
+              <p class="text-xs text-gray-400 mt-1">
                 Max 5MB, image files only
               </p>
             </div>
@@ -494,16 +519,16 @@ onMounted(fetchTags)
           </p>
         </div>
 
-        <!-- Tags -->
-        <div>
-          <label class="block text-sm font-medium text-text-secondary mb-3">
+        <!-- Tags Card -->
+        <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-6">
+          <label class="block text-sm font-medium text-gray-700 mb-3">
             Tags
           </label>
 
           <!-- Tags loading -->
           <div
             v-if="tagsLoading"
-            class="text-text-secondary text-sm"
+            class="text-gray-500 text-sm"
           >
             Loading tags...
           </div>
@@ -525,7 +550,7 @@ onMounted(fetchTags)
               v-for="[category, categoryTags] in tagsByCategory"
               :key="category"
             >
-              <h4 class="text-xs font-medium text-text-secondary uppercase tracking-wider mb-2">
+              <h4 class="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
                 {{ getCategoryDisplayName(category) }}
               </h4>
               <div class="flex flex-wrap gap-2">
@@ -533,7 +558,7 @@ onMounted(fetchTags)
                   v-for="tag in categoryTags"
                   :key="tag.id"
                   type="button"
-                  :class="getTagChipClass(tag.id, tag.category)"
+                  :class="['tag-btn', { 'selected': selectedTagIds.has(tag.id) }]"
                   @click="toggleTag(tag.id)"
                 >
                   {{ tag.name }}
@@ -542,7 +567,7 @@ onMounted(fetchTags)
             </div>
           </div>
 
-          <p class="mt-3 text-xs text-text-secondary">
+          <p class="mt-3 text-xs text-gray-500">
             {{ selectedTagIds.size }} tag{{ selectedTagIds.size === 1 ? '' : 's' }} selected
           </p>
         </div>
@@ -550,10 +575,10 @@ onMounted(fetchTags)
     </div>
 
     <!-- Form Actions -->
-    <div class="flex justify-end gap-3 mt-8 pt-6 border-t border-border">
+    <div class="sticky bottom-0 bg-white border-t border-gray-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)] -mx-6 px-6 py-4 mt-8 flex justify-end gap-3">
       <button
         type="button"
-        class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+        class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
         @click="emit('cancel')"
       >
         Cancel

--- a/frontend/src/components/ui/ConfirmDialog.vue
+++ b/frontend/src/components/ui/ConfirmDialog.vue
@@ -19,28 +19,30 @@ const emit = defineEmits<{
 <template>
   <div
     v-if="open"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
   >
-    <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-      <h2 class="text-lg font-semibold text-text-primary mb-4">
-        {{ title }}
-      </h2>
+    <div class="bg-white rounded-xl shadow-xl border border-gray-100 w-full max-w-md overflow-hidden">
+      <div class="p-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">
+          {{ title }}
+        </h2>
 
-      <p class="text-text-secondary mb-4">
-        {{ message }}
-      </p>
+        <p class="text-gray-500 mb-4">
+          {{ message }}
+        </p>
 
-      <div
-        v-if="error"
-        class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
-      >
-        {{ error }}
+        <div
+          v-if="error"
+          class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
+        >
+          {{ error }}
+        </div>
       </div>
 
-      <div class="flex justify-end gap-3">
+      <div class="flex justify-end gap-3 bg-gray-50 border-t border-gray-200 px-6 py-4">
         <button
           type="button"
-          class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+          class="rounded-lg bg-white border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
           @click="emit('cancel')"
         >
           {{ cancelLabel ?? 'Cancel' }}
@@ -48,7 +50,7 @@ const emit = defineEmits<{
         <button
           :disabled="loading"
           :class="[
-            variant === 'danger' ? 'bg-destructive hover:bg-destructive/90' :
+            variant === 'danger' ? 'bg-red-600 hover:bg-red-700' :
             variant === 'warning' ? 'bg-amber-500 hover:bg-amber-600' :
             'bg-accent hover:bg-accent-hover',
             'rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 transition-colors',

--- a/frontend/src/components/ui/EmptyState.vue
+++ b/frontend/src/components/ui/EmptyState.vue
@@ -15,17 +15,21 @@ const emit = defineEmits<{
 
 <template>
   <div class="text-center py-12">
-    <component
-      :is="icon"
+    <div
       v-if="icon"
-      class="mx-auto h-10 w-10 text-text-secondary mb-3"
-    />
-    <h3 class="text-base font-medium text-text-primary mb-1">
+      class="mx-auto h-16 w-16 bg-gray-50 rounded-full flex items-center justify-center mb-4"
+    >
+      <component
+        :is="icon"
+        class="h-8 w-8 text-gray-400"
+      />
+    </div>
+    <h3 class="text-base font-medium text-gray-900 mb-1">
       {{ title }}
     </h3>
     <p
       v-if="description"
-      class="text-sm text-text-secondary mb-4"
+      class="text-sm text-gray-500 mb-4"
     >
       {{ description }}
     </p>

--- a/frontend/src/components/ui/ErrorState.vue
+++ b/frontend/src/components/ui/ErrorState.vue
@@ -11,16 +11,21 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="bg-destructive/10 border border-destructive/30 rounded-lg px-4 py-3 flex items-center justify-between">
-    <div class="flex items-center gap-2">
-      <ExclamationTriangleIcon class="h-5 w-5 text-destructive flex-shrink-0" />
-      <span class="text-sm text-destructive">{{ message }}</span>
+  <div class="rounded-lg px-6 py-8 flex flex-col items-center text-center">
+    <div class="h-14 w-14 bg-red-100 rounded-full flex items-center justify-center mb-4">
+      <ExclamationTriangleIcon class="h-7 w-7 text-red-600 flex-shrink-0" />
     </div>
+    <h3 class="text-base font-medium text-gray-900 mb-1">
+      Something went wrong
+    </h3>
+    <p class="text-sm text-gray-500 mb-4">
+      {{ message }}
+    </p>
     <button
-      class="text-sm text-destructive underline hover:no-underline flex-shrink-0 ml-4"
+      class="text-sm font-medium text-accent hover:text-accent-hover underline hover:no-underline transition-colors"
       @click="emit('retry')"
     >
-      Retry
+      Try again
     </button>
   </div>
 </template>

--- a/frontend/src/components/ui/LoadingSkeleton.vue
+++ b/frontend/src/components/ui/LoadingSkeleton.vue
@@ -6,16 +6,16 @@ defineProps<{
 </script>
 
 <template>
-  <div class="animate-pulse">
+  <div>
     <!-- Card variant -->
     <template v-if="variant === 'card'">
       <div
         v-for="i in (count ?? 1)"
         :key="i"
-        class="rounded-xl border border-border bg-bg-secondary p-5 mb-4"
+        class="rounded-xl border border-gray-200 bg-white p-5 mb-4"
       >
-        <div class="h-4 w-24 bg-bg-tertiary rounded mb-3" />
-        <div class="h-8 w-16 bg-bg-tertiary rounded" />
+        <div class="h-4 w-24 bg-gray-200 shimmer rounded mb-3" />
+        <div class="h-8 w-16 bg-gray-100 shimmer rounded" />
       </div>
     </template>
 
@@ -26,10 +26,10 @@ defineProps<{
         :key="i"
         class="flex items-center gap-3 py-3"
       >
-        <div class="h-10 w-10 bg-bg-tertiary rounded-lg flex-shrink-0" />
+        <div class="h-10 w-10 bg-gray-200 shimmer rounded-lg flex-shrink-0" />
         <div class="flex-1">
-          <div class="h-4 w-40 bg-bg-tertiary rounded mb-1.5" />
-          <div class="h-3 w-24 bg-bg-tertiary rounded" />
+          <div class="h-4 w-40 bg-gray-200 shimmer rounded mb-1.5" />
+          <div class="h-3 w-24 bg-gray-100 shimmer rounded" />
         </div>
       </div>
     </template>
@@ -42,7 +42,7 @@ defineProps<{
         class="mb-3"
       >
         <div
-          class="h-4 bg-bg-tertiary rounded"
+          class="h-4 bg-gray-200 shimmer rounded"
           :style="{ width: `${70 + Math.random() * 30}%` }"
         />
       </div>

--- a/frontend/src/components/ui/Toast.vue
+++ b/frontend/src/components/ui/Toast.vue
@@ -18,17 +18,17 @@ const iconMap = {
 }
 
 const colorMap = {
-  success: 'border-green-500/30 bg-green-500/10',
-  error: 'border-destructive/30 bg-destructive/10',
-  warning: 'border-amber-500/30 bg-amber-500/10',
-  info: 'border-blue-500/30 bg-blue-500/10',
+  success: 'border-green-200 bg-green-50',
+  error: 'border-red-200 bg-red-50',
+  warning: 'border-amber-200 bg-amber-50',
+  info: 'border-blue-200 bg-blue-50',
 }
 
 const iconColorMap = {
-  success: 'text-green-400',
-  error: 'text-destructive',
-  warning: 'text-amber-400',
-  info: 'text-blue-400',
+  success: 'text-green-600',
+  error: 'text-red-600',
+  warning: 'text-amber-600',
+  info: 'text-blue-600',
 }
 </script>
 
@@ -54,11 +54,11 @@ const iconColorMap = {
           :is="iconMap[t.type]"
           :class="[iconColorMap[t.type], 'h-5 w-5 flex-shrink-0 mt-0.5']"
         />
-        <p class="text-sm text-text-primary flex-1">
+        <p class="text-sm text-gray-900 flex-1">
           {{ t.message }}
         </p>
         <button
-          class="text-text-secondary hover:text-text-primary transition-colors flex-shrink-0"
+          class="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
           @click="toast.remove(t.id)"
         >
           <XMarkIcon class="h-4 w-4" />

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -12,6 +12,7 @@ import {
   TagIcon,
   PhotoIcon,
   ArrowTrendingUpIcon,
+  ChevronRightIcon,
 } from '@heroicons/vue/24/outline'
 
 interface DashboardStats {
@@ -38,20 +39,21 @@ const loading = ref(true)
 const error = ref('')
 
 const statCards = [
-  { key: 'series_count' as const, label: 'Total Series', icon: FilmIcon, color: 'text-accent' },
-  { key: 'episode_count' as const, label: 'Total Episodes', icon: PlayCircleIcon, color: 'text-blue-400' },
-  { key: 'user_count' as const, label: 'Users', icon: UsersIcon, color: 'text-amber-400' },
-  { key: 'published_series_count' as const, label: 'Published', icon: CheckBadgeIcon, color: 'text-emerald-400' },
+  { key: 'series_count' as const, label: 'Total Series', icon: FilmIcon, iconColor: 'text-accent', iconBg: 'bg-accent-light', blur: 'bg-accent/5', blurHover: 'group-hover:bg-accent/10' },
+  { key: 'episode_count' as const, label: 'Total Episodes', icon: PlayCircleIcon, iconColor: 'text-blue-500', iconBg: 'bg-blue-50', blur: 'bg-blue-500/5', blurHover: 'group-hover:bg-blue-500/10' },
+  { key: 'user_count' as const, label: 'Users', icon: UsersIcon, iconColor: 'text-amber-500', iconBg: 'bg-amber-50', blur: 'bg-amber-500/5', blurHover: 'group-hover:bg-amber-500/10' },
+  { key: 'published_series_count' as const, label: 'Published', icon: CheckBadgeIcon, iconColor: 'text-emerald-600', iconBg: 'bg-emerald-50', blur: 'bg-emerald-100', blurHover: 'group-hover:bg-emerald-200' },
 ]
 
 function getStatusBadgeClass(status: string): string {
   switch (status) {
     case 'published':
-      return 'bg-green-500/15 text-green-400'
+      return 'bg-emerald-100 text-emerald-800'
+    case 'draft':
     case 'archived':
-      return 'bg-amber-500/15 text-amber-400'
+      return 'bg-amber-100 text-amber-800'
     default:
-      return 'bg-bg-tertiary text-text-secondary'
+      return 'bg-gray-100 text-gray-800'
   }
 }
 
@@ -97,23 +99,23 @@ onMounted(fetchDashboard)
     <!-- Header -->
     <div class="flex items-center justify-between mb-8">
       <div>
-        <h1 class="text-2xl font-bold text-text-primary">
+        <h1 class="text-2xl font-bold text-gray-900 tracking-tight">
           Dashboard
         </h1>
-        <p class="text-sm text-text-secondary mt-1">
+        <p class="text-sm text-gray-500 mt-1">
           Overview of your streaming platform
         </p>
       </div>
       <div class="flex items-center gap-3">
         <button
-          class="flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+          class="px-4 py-2 bg-white border border-border text-gray-700 text-sm font-medium rounded-lg shadow-[--shadow-subtle] hover:bg-gray-50 transition-all"
           @click="router.push('/tags')"
         >
-          <TagIcon class="h-4 w-4" />
+          <TagIcon class="inline h-4 w-4 mr-1.5 -mt-0.5" />
           Manage Tags
         </button>
         <button
-          class="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
+          class="px-4 py-2 bg-accent text-white text-sm font-medium rounded-lg shadow-sm hover:bg-accent-hover transition-all flex items-center gap-2"
           @click="router.push('/series/create')"
         >
           <PlusIcon class="h-4 w-4" />
@@ -125,7 +127,7 @@ onMounted(fetchDashboard)
     <!-- Error -->
     <div
       v-if="error"
-      class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-6"
+      class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-6"
     >
       {{ error }}
       <button
@@ -142,15 +144,15 @@ onMounted(fetchDashboard)
         <div
           v-for="i in 4"
           :key="i"
-          class="rounded-xl border border-border bg-bg-secondary p-5 animate-pulse"
+          class="bg-white rounded-xl border border-border p-5 animate-pulse"
         >
-          <div class="h-4 w-20 bg-bg-tertiary rounded mb-3" />
-          <div class="h-8 w-16 bg-bg-tertiary rounded" />
+          <div class="h-4 w-20 bg-gray-200 rounded mb-3" />
+          <div class="h-8 w-16 bg-gray-100 rounded" />
         </div>
       </div>
-      <div class="rounded-xl border border-border bg-bg-secondary animate-pulse">
-        <div class="p-5 border-b border-border">
-          <div class="h-5 w-32 bg-bg-tertiary rounded" />
+      <div class="bg-white rounded-xl border border-border animate-pulse">
+        <div class="p-5 border-b border-gray-100">
+          <div class="h-5 w-32 bg-gray-200 rounded" />
         </div>
         <div class="p-5 space-y-4">
           <div
@@ -158,10 +160,10 @@ onMounted(fetchDashboard)
             :key="i"
             class="flex items-center gap-3"
           >
-            <div class="h-10 w-10 bg-bg-tertiary rounded-lg" />
+            <div class="h-10 w-10 bg-gray-200 rounded-lg" />
             <div class="flex-1">
-              <div class="h-4 w-40 bg-bg-tertiary rounded mb-1" />
-              <div class="h-3 w-24 bg-bg-tertiary rounded" />
+              <div class="h-4 w-40 bg-gray-200 rounded mb-1" />
+              <div class="h-3 w-24 bg-gray-100 rounded" />
             </div>
           </div>
         </div>
@@ -175,32 +177,41 @@ onMounted(fetchDashboard)
         <div
           v-for="card in statCards"
           :key="card.key"
-          class="rounded-xl border border-border bg-bg-secondary p-5 hover:border-border/80 transition-colors"
+          class="group bg-white p-6 rounded-xl border border-border shadow-[--shadow-card] hover:shadow-[--shadow-floating] transition-all duration-300 cursor-pointer relative overflow-hidden"
         >
-          <div class="flex items-center justify-between mb-3">
-            <span class="text-sm font-medium text-text-secondary">{{ card.label }}</span>
-            <component
-              :is="card.icon"
-              :class="[card.color, 'h-5 w-5']"
-            />
+          <div
+            :class="[card.blur, card.blurHover, 'absolute top-0 right-0 w-24 h-24 rounded-full blur-2xl -mr-10 -mt-10 transition-all']"
+          />
+          <div class="relative flex items-center justify-between mb-3">
+            <div
+              :class="[card.iconBg, 'w-10 h-10 rounded-full flex items-center justify-center']"
+            >
+              <component
+                :is="card.icon"
+                :class="[card.iconColor, 'h-5 w-5']"
+              />
+            </div>
           </div>
-          <div class="text-3xl font-bold text-text-primary tracking-tight">
-            {{ stats?.[card.key] ?? 0 }}
+          <div class="relative">
+            <span class="text-sm font-medium text-gray-500">{{ card.label }}</span>
+            <div class="text-3xl font-bold text-gray-900 mt-1">
+              {{ stats?.[card.key] ?? 0 }}
+            </div>
           </div>
         </div>
       </div>
 
       <!-- Recent Series -->
-      <div class="rounded-xl border border-border bg-bg-secondary">
-        <div class="flex items-center justify-between p-5 border-b border-border">
+      <div class="bg-white rounded-xl border border-border shadow-[--shadow-card] overflow-hidden">
+        <div class="px-4 py-4 border-b border-gray-100 flex items-center justify-between">
           <div class="flex items-center gap-2">
-            <ArrowTrendingUpIcon class="h-5 w-5 text-text-secondary" />
-            <h2 class="text-base font-semibold text-text-primary">
+            <ArrowTrendingUpIcon class="h-5 w-5 text-gray-500" />
+            <h2 class="text-lg font-semibold text-gray-900">
               Recent Activity
             </h2>
           </div>
           <button
-            class="text-sm text-accent hover:text-accent-hover transition-colors"
+            class="text-sm font-medium text-accent hover:text-accent-hover transition-colors"
             @click="router.push('/series')"
           >
             View all
@@ -212,9 +223,14 @@ onMounted(fetchDashboard)
           v-if="recentSeries.length === 0"
           class="py-12 text-center"
         >
-          <FilmIcon class="mx-auto h-10 w-10 text-text-secondary mb-3" />
-          <p class="text-sm text-text-secondary mb-4">
-            No series yet. Create your first one to get started.
+          <div class="bg-gray-50 rounded-full p-4 inline-block mb-3">
+            <FilmIcon class="mx-auto h-10 w-10 text-gray-500" />
+          </div>
+          <p class="text-sm font-medium text-gray-900 mb-1">
+            No series yet
+          </p>
+          <p class="text-sm text-gray-500 mb-4">
+            Create your first one to get started.
           </p>
           <button
             class="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
@@ -228,47 +244,56 @@ onMounted(fetchDashboard)
         <!-- Series List -->
         <div
           v-else
-          class="divide-y divide-border"
+          class="divide-y divide-gray-100"
         >
           <button
             v-for="s in recentSeries"
             :key="s.id"
-            class="flex items-center gap-4 w-full px-5 py-3.5 text-left hover:bg-bg-tertiary/50 transition-colors"
+            class="group flex items-center justify-between p-4 hover:bg-[#F9FAFB] transition-colors cursor-pointer w-full text-left"
             @click="router.push(`/series/${s.id}`)"
           >
-            <!-- Thumbnail -->
-            <div class="flex-shrink-0 h-10 w-10 rounded-lg bg-bg-tertiary flex items-center justify-center overflow-hidden">
-              <img
-                v-if="s.thumbnail_url"
-                :src="s.thumbnail_url"
-                :alt="s.title"
-                class="h-full w-full object-cover"
+            <div class="flex items-center gap-4 min-w-0 flex-1">
+              <!-- Thumbnail -->
+              <div class="relative w-12 h-12 rounded-lg overflow-hidden border border-gray-100 shadow-sm shrink-0">
+                <img
+                  v-if="s.thumbnail_url"
+                  :src="s.thumbnail_url"
+                  :alt="s.title"
+                  class="h-full w-full object-cover group-hover:scale-105 transition-transform duration-500"
+                >
+                <div
+                  v-else
+                  class="h-full w-full bg-gray-50 flex items-center justify-center"
+                >
+                  <PhotoIcon class="h-5 w-5 text-gray-400" />
+                </div>
+              </div>
+
+              <!-- Info -->
+              <div class="min-w-0">
+                <p class="text-sm font-semibold text-gray-900 group-hover:text-accent transition-colors truncate">
+                  {{ s.title }}
+                </p>
+                <p class="text-xs text-gray-500 mt-0.5">
+                  Updated {{ formatRelativeTime(s.updated_at) }}
+                </p>
+              </div>
+            </div>
+
+            <div class="flex items-center gap-3 shrink-0 ml-4">
+              <!-- Status Badge -->
+              <span
+                :class="[
+                  getStatusBadgeClass(s.status),
+                  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize',
+                ]"
               >
-              <PhotoIcon
-                v-else
-                class="h-5 w-5 text-text-secondary"
-              />
-            </div>
+                {{ s.status }}
+              </span>
 
-            <!-- Info -->
-            <div class="flex-1 min-w-0">
-              <p class="text-sm font-medium text-text-primary truncate">
-                {{ s.title }}
-              </p>
-              <p class="text-xs text-text-secondary">
-                Updated {{ formatRelativeTime(s.updated_at) }}
-              </p>
+              <!-- Chevron -->
+              <ChevronRightIcon class="h-4 w-4 text-gray-400 group-hover:text-gray-600 transition-colors" />
             </div>
-
-            <!-- Status Badge -->
-            <span
-              :class="[
-                getStatusBadgeClass(s.status),
-                'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize flex-shrink-0',
-              ]"
-            >
-              {{ s.status }}
-            </span>
           </button>
         </div>
       </div>

--- a/frontend/src/views/EpisodeCreateView.vue
+++ b/frontend/src/views/EpisodeCreateView.vue
@@ -31,14 +31,14 @@ async function handleSubmit(data: Record<string, unknown>) {
 <template>
   <div>
     <button
-      class="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors mb-4"
+      class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-accent transition-colors mb-4 group"
       @click="router.push(`/series/${seriesId}`)"
     >
-      <ArrowLeftIcon class="h-4 w-4" />
+      <ArrowLeftIcon class="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
       Back to Episodes
     </button>
 
-    <h1 class="text-2xl font-bold text-text-primary mb-6">
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight mb-6">
       Add Episode
     </h1>
     <div

--- a/frontend/src/views/EpisodeEditView.vue
+++ b/frontend/src/views/EpisodeEditView.vue
@@ -80,21 +80,21 @@ onMounted(fetchEpisode)
 <template>
   <div>
     <button
-      class="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors mb-4"
+      class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-accent transition-colors mb-4 group"
       @click="router.push(`/series/${seriesId}`)"
     >
-      <ArrowLeftIcon class="h-4 w-4" />
+      <ArrowLeftIcon class="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
       Back to Episodes
     </button>
 
-    <h1 class="text-2xl font-bold text-text-primary mb-6">
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight mb-6">
       Edit Episode
     </h1>
 
     <!-- Loading state -->
     <div
       v-if="fetchLoading"
-      class="text-text-secondary"
+      class="text-gray-500"
     >
       Loading episode...
     </div>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -35,113 +35,125 @@ function handleGoogleLogin() {
     <div class="w-full max-w-sm">
       <!-- Logo -->
       <div class="text-center mb-8">
-        <h1 class="text-3xl font-bold text-accent">
-          nDrama
-        </h1>
-        <p class="text-text-secondary mt-2">
+        <div class="inline-flex items-center gap-2">
+          <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-accent">
+            <svg
+              class="h-5 w-5 text-white"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </div>
+          <span class="text-2xl font-bold text-gray-900">Draama</span>
+        </div>
+        <p class="text-gray-500 mt-2">
           Sign in to your account
         </p>
       </div>
 
-      <!-- Login form -->
-      <form
-        class="space-y-4"
-        @submit.prevent="handleLogin"
-      >
-        <!-- Error message -->
-        <div
-          v-if="error"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm"
+      <!-- Login card -->
+      <div class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-8">
+        <!-- Login form -->
+        <form
+          class="space-y-4"
+          @submit.prevent="handleLogin"
         >
-          {{ error }}
+          <!-- Error message -->
+          <div
+            v-if="error"
+            class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm"
+          >
+            {{ error }}
+          </div>
+
+          <!-- Email -->
+          <div>
+            <label
+              for="email"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              v-model="email"
+              type="email"
+              required
+              autocomplete="email"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              placeholder="you@example.com"
+            >
+          </div>
+
+          <!-- Password -->
+          <div>
+            <label
+              for="password"
+              class="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              v-model="password"
+              type="password"
+              required
+              autocomplete="current-password"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              placeholder="Enter your password"
+            >
+          </div>
+
+          <!-- Submit -->
+          <button
+            type="submit"
+            :disabled="loading"
+            class="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {{ loading ? 'Signing in...' : 'Sign in' }}
+          </button>
+        </form>
+
+        <!-- Divider -->
+        <div class="relative my-6">
+          <div class="absolute inset-0 flex items-center">
+            <div class="w-full border-t border-gray-200" />
+          </div>
+          <div class="relative flex justify-center text-sm">
+            <span class="bg-white px-2 text-gray-500">or</span>
+          </div>
         </div>
 
-        <!-- Email -->
-        <div>
-          <label
-            for="email"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Email
-          </label>
-          <input
-            id="email"
-            v-model="email"
-            type="email"
-            required
-            autocomplete="email"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary placeholder-text-secondary/50 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="you@example.com"
-          >
-        </div>
-
-        <!-- Password -->
-        <div>
-          <label
-            for="password"
-            class="block text-sm font-medium text-text-secondary mb-1"
-          >
-            Password
-          </label>
-          <input
-            id="password"
-            v-model="password"
-            type="password"
-            required
-            autocomplete="current-password"
-            class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary placeholder-text-secondary/50 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
-            placeholder="Enter your password"
-          >
-        </div>
-
-        <!-- Submit -->
+        <!-- Google OAuth -->
         <button
-          type="submit"
-          :disabled="loading"
-          class="w-full rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          class="w-full flex items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 shadow-[--shadow-subtle] focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 transition-colors"
+          @click="handleGoogleLogin"
         >
-          {{ loading ? 'Signing in...' : 'Sign in' }}
+          <svg
+            class="h-5 w-5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
+          </svg>
+          Sign in with Google
         </button>
-      </form>
-
-      <!-- Divider -->
-      <div class="relative my-6">
-        <div class="absolute inset-0 flex items-center">
-          <div class="w-full border-t border-border" />
-        </div>
-        <div class="relative flex justify-center text-sm">
-          <span class="bg-bg-primary px-2 text-text-secondary">or</span>
-        </div>
       </div>
-
-      <!-- Google OAuth -->
-      <button
-        class="w-full flex items-center justify-center gap-3 rounded-lg border border-border bg-bg-secondary px-4 py-2 text-sm font-medium text-text-primary hover:bg-bg-tertiary focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg-primary transition-colors"
-        @click="handleGoogleLogin"
-      >
-        <svg
-          class="h-5 w-5"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-            fill="#4285F4"
-          />
-          <path
-            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            fill="#34A853"
-          />
-          <path
-            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-            fill="#FBBC05"
-          />
-          <path
-            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            fill="#EA4335"
-          />
-        </svg>
-        Sign in with Google
-      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/views/SeriesCreateView.vue
+++ b/frontend/src/views/SeriesCreateView.vue
@@ -27,7 +27,27 @@ async function handleSubmit(data: Record<string, unknown>) {
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-text-primary mb-6">
+    <RouterLink
+      to="/series"
+      class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-accent transition-colors mb-4 group"
+    >
+      <svg
+        class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
+      </svg>
+      Back to Series
+    </RouterLink>
+
+    <h1 class="text-2xl font-bold text-gray-900 tracking-tight mb-6">
       Create Series
     </h1>
     <div

--- a/frontend/src/views/SeriesDetailView.vue
+++ b/frontend/src/views/SeriesDetailView.vue
@@ -146,13 +146,13 @@ async function confirmDelete() {
 function getStatusBadgeClass(status: string): string {
   switch (status) {
     case 'published':
-      return 'bg-green-500/15 text-green-400'
+      return 'bg-emerald-50 text-emerald-700 border border-emerald-200'
     case 'ready':
-      return 'bg-blue-500/15 text-blue-400'
+      return 'bg-blue-50 text-blue-700 border border-blue-200'
     case 'processing':
-      return 'bg-amber-500/15 text-amber-400'
+      return 'bg-amber-50 text-amber-700 border border-amber-200'
     default:
-      return 'bg-bg-tertiary text-text-secondary'
+      return 'bg-gray-100 text-gray-600 border border-gray-200'
   }
 }
 
@@ -166,12 +166,12 @@ function formatDuration(seconds: number | null): string {
 function getEpisodePricingBadge(episodeNumber: number): { label: string; class: string } {
   if (!series.value) return { label: '', class: '' }
   if (episodeNumber <= series.value.free_episode_count) {
-    return { label: 'Free', class: 'bg-green-500/10 text-green-400' }
+    return { label: 'Free', class: 'bg-emerald-50 text-emerald-700 border border-emerald-200' }
   }
   const cost = series.value.coin_cost_per_episode
   return {
     label: cost > 0 ? `${cost} coins` : 'Locked',
-    class: 'bg-amber-500/10 text-amber-400',
+    class: 'bg-amber-50 text-amber-700 border border-amber-200',
   }
 }
 
@@ -194,7 +194,7 @@ onMounted(() => {
     <!-- Back button + Series Header -->
     <div class="mb-6">
       <button
-        class="flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors mb-4"
+        class="flex items-center gap-1.5 text-sm text-gray-500 hover:text-accent transition-colors mb-4"
         @click="router.push('/series')"
       >
         <ArrowLeftIcon class="h-4 w-4" />
@@ -206,11 +206,11 @@ onMounted(() => {
         v-if="seriesLoading"
         class="flex items-start gap-4 animate-pulse"
       >
-        <div class="h-20 w-20 bg-bg-tertiary rounded-lg flex-shrink-0" />
+        <div class="h-20 w-20 bg-gray-100 rounded-xl flex-shrink-0" />
         <div class="flex-1">
-          <div class="h-6 w-48 bg-bg-tertiary rounded mb-2" />
-          <div class="h-4 w-72 bg-bg-tertiary rounded mb-2" />
-          <div class="h-3 w-40 bg-bg-tertiary rounded" />
+          <div class="h-6 w-48 bg-gray-100 rounded mb-2" />
+          <div class="h-4 w-72 bg-gray-100 rounded mb-2" />
+          <div class="h-3 w-40 bg-gray-100 rounded" />
         </div>
       </div>
       <div
@@ -223,24 +223,26 @@ onMounted(() => {
       <!-- Series info header -->
       <div
         v-else-if="series"
-        class="flex items-start gap-4"
+        class="bg-white rounded-xl shadow-[--shadow-card] border border-border p-4 md:p-6 flex items-start gap-4"
       >
         <!-- Thumbnail -->
-        <div class="flex-shrink-0 h-20 w-20 rounded-lg bg-bg-tertiary flex items-center justify-center overflow-hidden border border-border">
+        <div class="flex-shrink-0 h-20 w-20 rounded-xl overflow-hidden shadow-sm border border-gray-100 group">
           <img
             v-if="series.thumbnail_url"
             :src="series.thumbnail_url"
             :alt="series.title"
-            class="h-full w-full object-cover"
+            class="h-full w-full object-cover group-hover:scale-105 transition-transform"
           >
-          <FilmIcon
+          <div
             v-else
-            class="h-8 w-8 text-text-secondary"
-          />
+            class="h-full w-full bg-gray-50 flex items-center justify-center"
+          >
+            <FilmIcon class="h-8 w-8 text-gray-400" />
+          </div>
         </div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-3 mb-1">
-            <h1 class="text-2xl font-bold text-text-primary truncate">
+            <h1 class="text-xl md:text-2xl lg:text-3xl font-bold text-gray-900 tracking-tight truncate">
               {{ series.title }}
             </h1>
             <span
@@ -254,22 +256,29 @@ onMounted(() => {
           </div>
           <p
             v-if="series.description"
-            class="text-sm text-text-secondary line-clamp-2 mb-2"
+            class="text-sm text-gray-500 leading-relaxed line-clamp-2 mb-2"
           >
             {{ series.description }}
           </p>
-          <div class="flex items-center gap-4 text-xs text-text-secondary">
+          <div class="flex items-center gap-4 text-xs text-gray-600">
             <span>{{ total }} episode{{ total === 1 ? '' : 's' }}</span>
+            <span class="text-gray-300">&middot;</span>
             <span>{{ series.free_episode_count }} free</span>
+            <span class="text-gray-300">&middot;</span>
             <span>{{ series.coin_cost_per_episode }} coins/ep</span>
             <div
               v-if="series.tags.length"
               class="flex gap-1"
             >
               <span
-                v-for="tag in series.tags.slice(0, 3)"
+                v-for="(tag, index) in series.tags.slice(0, 3)"
                 :key="tag.id"
-                class="inline-flex items-center rounded-full bg-accent/15 text-accent px-2 py-0.5 text-xs font-medium"
+                :class="[
+                  index % 3 === 0 ? 'bg-blue-50 text-blue-700 border border-blue-100' :
+                  index % 3 === 1 ? 'bg-purple-50 text-purple-700 border border-purple-100' :
+                  'bg-green-50 text-green-700 border border-green-100',
+                  'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                ]"
               >
                 {{ tag.name }}
               </span>
@@ -277,7 +286,7 @@ onMounted(() => {
           </div>
         </div>
         <button
-          class="flex-shrink-0 flex items-center gap-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors border border-border rounded-lg px-3 py-1.5"
+          class="flex-shrink-0 flex items-center gap-1.5 text-sm border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 transition-colors rounded-lg px-3 py-1.5"
           @click="router.push(`/series/${series.id}/edit`)"
         >
           <PencilIcon class="h-4 w-4" />
@@ -290,9 +299,14 @@ onMounted(() => {
     <div class="mt-8">
       <!-- Episodes Header -->
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-text-primary">
-          Episodes
-        </h2>
+        <div class="flex items-center gap-2">
+          <h2 class="text-lg font-semibold text-gray-900">
+            Episodes
+          </h2>
+          <span class="bg-gray-100 text-gray-600 border border-gray-200 rounded-full px-2 py-0.5 text-xs font-medium">
+            {{ total }}
+          </span>
+        </div>
         <button
           class="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover transition-colors"
           @click="router.push(`/series/${seriesId}/episodes/create`)"
@@ -313,73 +327,73 @@ onMounted(() => {
       <!-- Episodes loading skeleton -->
       <div
         v-if="episodesLoading"
-        class="overflow-hidden rounded-xl border border-border animate-pulse"
+        class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card] animate-pulse"
       >
-        <div class="border-b border-border bg-bg-secondary px-4 py-3">
-          <div class="h-4 w-32 bg-bg-tertiary rounded" />
+        <div class="border-b border-gray-200 bg-[#F9FAFB] px-4 py-3">
+          <div class="h-4 w-32 bg-gray-200 rounded" />
         </div>
         <div
           v-for="i in 3"
           :key="i"
-          class="flex items-center gap-4 px-4 py-3 border-b border-border last:border-0"
+          class="flex items-center gap-4 px-4 py-3 border-b border-gray-200 last:border-0"
         >
-          <div class="h-4 w-6 bg-bg-tertiary rounded" />
-          <div class="h-10 w-16 bg-bg-tertiary rounded" />
+          <div class="h-4 w-6 bg-gray-100 rounded" />
+          <div class="h-10 w-16 bg-gray-100 rounded" />
           <div class="flex-1">
-            <div class="h-4 w-36 bg-bg-tertiary rounded mb-1" />
-            <div class="h-3 w-24 bg-bg-tertiary rounded" />
+            <div class="h-4 w-36 bg-gray-100 rounded mb-1" />
+            <div class="h-3 w-24 bg-gray-100 rounded" />
           </div>
-          <div class="h-5 w-16 bg-bg-tertiary rounded-full" />
+          <div class="h-5 w-16 bg-gray-100 rounded-full" />
         </div>
       </div>
 
       <!-- Episodes Table -->
       <div
         v-else-if="episodes.length > 0"
-        class="overflow-hidden rounded-xl border border-border"
+        class="bg-white rounded-xl border border-border shadow-[--shadow-card] overflow-hidden"
       >
         <table class="w-full">
           <thead>
-            <tr class="border-b border-border bg-bg-secondary">
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-12">
+            <tr class="border-b border-gray-200 bg-[#F9FAFB]">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-12">
                 #
               </th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
                 Episode
               </th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-28">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-28">
                 Status
               </th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-24">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-24">
                 Access
               </th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-24">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-24">
                 Duration
               </th>
-              <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider w-32">
+              <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider w-32">
                 Created
               </th>
-              <th class="px-4 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider w-16">
+              <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider w-16">
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody class="divide-y divide-border">
+          <tbody class="divide-y divide-gray-200">
             <tr
               v-for="ep in episodes"
               :key="ep.id"
-              class="hover:bg-bg-secondary/50 transition-colors cursor-pointer"
+              class="hover:bg-gray-50 transition-colors cursor-pointer"
               @click="router.push(`/series/${seriesId}/episodes/${ep.id}/edit`)"
             >
               <td class="px-4 py-3">
-                <span class="text-sm font-mono text-text-secondary">
+                <span class="text-sm font-mono text-gray-500">
                   {{ ep.episode_number }}
                 </span>
               </td>
               <td class="px-4 py-3">
                 <div class="flex items-center gap-3">
                   <!-- Video thumbnail / placeholder -->
-                  <div class="flex-shrink-0 h-10 w-16 rounded bg-bg-tertiary flex items-center justify-center overflow-hidden border border-border/50">
+                  <div class="flex-shrink-0 h-10 w-16 rounded bg-gray-50 flex items-center justify-center overflow-hidden border border-gray-100">
                     <img
                       v-if="ep.thumbnail_url"
                       :src="ep.thumbnail_url"
@@ -388,16 +402,16 @@ onMounted(() => {
                     >
                     <PlayCircleIcon
                       v-else
-                      class="h-5 w-5 text-text-secondary"
+                      class="h-5 w-5 text-gray-400"
                     />
                   </div>
                   <div class="min-w-0">
-                    <p class="text-sm font-medium text-text-primary truncate">
+                    <p class="text-sm font-medium text-gray-900 truncate">
                       {{ ep.title }}
                     </p>
                     <p
                       v-if="ep.description"
-                      class="text-xs text-text-secondary line-clamp-1"
+                      class="text-xs text-gray-500 line-clamp-1"
                     >
                       {{ ep.description }}
                     </p>
@@ -422,10 +436,10 @@ onMounted(() => {
                   {{ getEpisodePricingBadge(ep.episode_number).label }}
                 </span>
               </td>
-              <td class="px-4 py-3 text-sm text-text-secondary font-mono">
+              <td class="px-4 py-3 text-sm text-gray-500 font-mono">
                 {{ formatDuration(ep.duration_seconds) }}
               </td>
-              <td class="px-4 py-3 text-sm text-text-secondary">
+              <td class="px-4 py-3 text-sm text-gray-500">
                 {{ formatDate(ep.created_at) }}
               </td>
               <td
@@ -436,14 +450,14 @@ onMounted(() => {
                   as="div"
                   class="relative inline-block text-left"
                 >
-                  <MenuButton class="text-text-secondary hover:text-text-primary transition-colors">
+                  <MenuButton class="text-gray-400 hover:text-gray-700 transition-colors">
                     <EllipsisVerticalIcon class="h-5 w-5" />
                   </MenuButton>
-                  <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-bg-secondary border border-border shadow-lg focus:outline-none">
+                  <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-white border border-border shadow-lg focus:outline-none">
                     <div class="py-1">
                       <MenuItem v-slot="{ active }">
                         <button
-                          :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-text-primary flex items-center gap-2']"
+                          :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-gray-700 flex items-center gap-2']"
                           @click="router.push(`/series/${seriesId}/episodes/${ep.id}/edit`)"
                         >
                           <PencilIcon class="h-4 w-4" />
@@ -452,7 +466,7 @@ onMounted(() => {
                       </MenuItem>
                       <MenuItem v-slot="{ active }">
                         <button
-                          :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-destructive flex items-center gap-2']"
+                          :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-destructive flex items-center gap-2']"
                           @click="openDeleteConfirm(ep)"
                         >
                           <TrashIcon class="h-4 w-4" />
@@ -473,11 +487,13 @@ onMounted(() => {
         v-else-if="!episodesLoading"
         class="text-center py-16 border border-border/50 rounded-xl border-dashed"
       >
-        <FilmIcon class="mx-auto h-12 w-12 text-text-secondary mb-4" />
-        <h3 class="text-lg font-medium text-text-primary mb-2">
+        <div class="mx-auto h-12 w-12 rounded-full bg-gray-50 flex items-center justify-center mb-4">
+          <FilmIcon class="h-6 w-6 text-gray-400" />
+        </div>
+        <h3 class="text-lg font-medium text-gray-900 mb-2">
           No episodes yet
         </h3>
-        <p class="text-text-secondary mb-6 text-sm">
+        <p class="text-gray-500 mb-6 text-sm">
           Add the first episode to this series
         </p>
         <button
@@ -493,30 +509,32 @@ onMounted(() => {
     <!-- Delete Confirmation Modal -->
     <div
       v-if="showDeleteConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
-          Delete Episode
-        </h2>
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl w-full max-w-md overflow-hidden">
+        <div class="p-6">
+          <h2 class="text-lg font-semibold text-gray-900 mb-4">
+            Delete Episode
+          </h2>
 
-        <p class="text-text-secondary mb-4">
-          Are you sure you want to delete episode {{ deletingEpisode?.episode_number }}
-          "{{ deletingEpisode?.title }}"? This will also remove the associated video.
-          This action cannot be undone.
-        </p>
+          <p class="text-gray-500 mb-4">
+            Are you sure you want to delete episode {{ deletingEpisode?.episode_number }}
+            "{{ deletingEpisode?.title }}"? This will also remove the associated video.
+            This action cannot be undone.
+          </p>
 
-        <div
-          v-if="deleteError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
-        >
-          {{ deleteError }}
+          <div
+            v-if="deleteError"
+            class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          >
+            {{ deleteError }}
+          </div>
         </div>
 
-        <div class="flex justify-end gap-3">
+        <div class="flex justify-end gap-3 bg-gray-50 px-6 py-4">
           <button
             type="button"
-            class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+            class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
             @click="showDeleteConfirm = false"
           >
             Cancel

--- a/frontend/src/views/SeriesEditView.vue
+++ b/frontend/src/views/SeriesEditView.vue
@@ -88,14 +88,47 @@ onMounted(fetchSeries)
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-text-primary mb-6">
-      Edit Series
-    </h1>
+    <RouterLink
+      to="/series"
+      class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-accent transition-colors mb-4 group"
+    >
+      <svg
+        class="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7"
+        />
+      </svg>
+      Back to Series
+    </RouterLink>
+
+    <div class="flex items-center gap-3 mb-6">
+      <h1 class="text-2xl font-bold text-gray-900 tracking-tight">
+        Edit Series
+      </h1>
+      <span
+        v-if="series"
+        :class="[
+          'badge-pill',
+          series.status === 'published' ? 'bg-accent-light text-accent' :
+          series.status === 'archived' ? 'bg-gray-100 text-gray-600' :
+          'bg-warning-light text-warning'
+        ]"
+      >
+        {{ series.status }}
+      </span>
+    </div>
 
     <!-- Loading state -->
     <div
       v-if="fetchLoading"
-      class="text-text-secondary"
+      class="text-gray-500"
     >
       Loading series...
     </div>

--- a/frontend/src/views/SeriesView.vue
+++ b/frontend/src/views/SeriesView.vue
@@ -188,11 +188,11 @@ async function confirmDelete() {
 function getStatusBadgeClass(status: string): string {
   switch (status) {
     case 'published':
-      return 'bg-green-500/15 text-green-400'
+      return 'bg-emerald-50 text-emerald-700 border border-emerald-200'
     case 'archived':
-      return 'bg-amber-500/15 text-amber-400'
+      return 'bg-amber-50 text-amber-700 border border-amber-200'
     default:
-      return 'bg-bg-tertiary text-text-secondary'
+      return 'bg-gray-100 text-gray-600 border border-gray-200'
   }
 }
 
@@ -227,7 +227,7 @@ onMounted(() => {
   <div>
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-text-primary">
+      <h1 class="text-2xl font-bold text-gray-900">
         Series
       </h1>
       <button
@@ -251,19 +251,19 @@ onMounted(() => {
     <div class="flex flex-wrap gap-4 mb-6">
       <!-- Search Input -->
       <div class="relative flex-1 min-w-[300px]">
-        <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-text-secondary" />
+        <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
         <input
           v-model="searchQuery"
           type="text"
           placeholder="Search series..."
-          class="w-full rounded-lg border border-border bg-bg-tertiary pl-10 pr-3 py-2 text-text-primary placeholder-text-secondary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+          class="w-full rounded-lg border border-border bg-white pl-10 pr-3 py-2 text-gray-900 placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent shadow-[--shadow-subtle]"
         >
       </div>
 
       <!-- Status Filter -->
       <select
         v-model="statusFilter"
-        class="rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+        class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
       >
         <option value="all">
           All Status
@@ -283,7 +283,7 @@ onMounted(() => {
       <select
         v-model="selectedTag"
         :disabled="tagsLoading"
-        class="rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
+        class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
       >
         <option value="">
           All Tags
@@ -301,63 +301,63 @@ onMounted(() => {
     <!-- Loading Skeleton -->
     <div
       v-if="loading"
-      class="overflow-hidden rounded-xl border border-border animate-pulse"
+      class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card] animate-pulse"
     >
-      <div class="border-b border-border bg-bg-secondary px-4 py-3">
-        <div class="h-4 w-32 bg-bg-tertiary rounded" />
+      <div class="border-b border-gray-200 bg-[#F9FAFB] px-4 py-3">
+        <div class="h-4 w-32 bg-gray-200 rounded" />
       </div>
       <div
         v-for="i in 5"
         :key="i"
-        class="flex items-center gap-4 px-4 py-3 border-b border-border last:border-0"
+        class="flex items-center gap-4 px-4 py-3 border-b border-gray-200 last:border-0"
       >
-        <div class="h-10 w-10 bg-bg-tertiary rounded-lg flex-shrink-0" />
+        <div class="h-10 w-10 bg-gray-100 rounded-lg flex-shrink-0" />
         <div class="flex-1">
-          <div class="h-4 w-40 bg-bg-tertiary rounded mb-1" />
-          <div class="h-3 w-24 bg-bg-tertiary rounded" />
+          <div class="h-4 w-40 bg-gray-100 rounded mb-1" />
+          <div class="h-3 w-24 bg-gray-100 rounded" />
         </div>
-        <div class="h-5 w-16 bg-bg-tertiary rounded-full" />
+        <div class="h-5 w-16 bg-gray-100 rounded-full" />
       </div>
     </div>
 
     <!-- Series Table -->
     <div
       v-else-if="series.length > 0"
-      class="overflow-hidden rounded-xl border border-border"
+      class="bg-white rounded-xl border border-border shadow-[--shadow-card] overflow-hidden"
     >
       <table class="w-full">
         <thead>
-          <tr class="border-b border-border bg-bg-secondary">
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+          <tr class="border-b border-gray-200 bg-[#F9FAFB]">
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Series
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Status
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Tags
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Pricing
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Created
             </th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wider">
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-border">
+        <tbody class="divide-y divide-gray-200">
           <tr
             v-for="s in series"
             :key="s.id"
-            class="hover:bg-bg-secondary/50 transition-colors"
+            class="hover:bg-gray-50 transition-colors"
           >
             <td class="px-4 py-3">
               <div class="flex items-center gap-3">
                 <!-- Thumbnail -->
-                <div class="flex-shrink-0 h-10 w-10 rounded-lg bg-bg-tertiary flex items-center justify-center overflow-hidden">
+                <div class="flex-shrink-0 h-10 w-10 rounded-lg bg-gray-50 flex items-center justify-center overflow-hidden">
                   <img
                     v-if="s.thumbnail_url"
                     :src="s.thumbnail_url"
@@ -366,20 +366,20 @@ onMounted(() => {
                   >
                   <PhotoIcon
                     v-else
-                    class="h-5 w-5 text-text-secondary"
+                    class="h-5 w-5 text-gray-400"
                   />
                 </div>
                 <!-- Title and Description -->
                 <div>
                   <button
-                    class="text-sm font-medium text-text-primary hover:text-accent transition-colors text-left"
+                    class="text-sm font-medium text-gray-900 hover:text-accent transition-colors text-left"
                     @click="router.push(`/series/${s.id}`)"
                   >
                     {{ s.title }}
                   </button>
                   <p
                     v-if="s.description"
-                    class="text-xs text-text-secondary line-clamp-1"
+                    class="text-xs text-gray-500 line-clamp-1"
                   >
                     {{ s.description }}
                   </p>
@@ -401,20 +401,20 @@ onMounted(() => {
                 <span
                   v-for="tag in s.tags.slice(0, 3)"
                   :key="tag.id"
-                  class="inline-flex items-center rounded-full bg-accent/15 text-accent px-2 py-0.5 text-xs font-medium"
+                  class="inline-flex items-center rounded-full bg-blue-50 text-blue-700 border border-blue-100 px-2 py-0.5 text-xs font-medium"
                 >
                   {{ tag.name }}
                 </span>
                 <span
                   v-if="s.tags.length > 3"
-                  class="inline-flex items-center rounded-full bg-bg-tertiary text-text-secondary px-2 py-0.5 text-xs font-medium"
+                  class="inline-flex items-center rounded-full bg-gray-100 text-gray-600 border border-gray-200 px-2 py-0.5 text-xs font-medium"
                 >
                   +{{ s.tags.length - 3 }}
                 </span>
               </div>
             </td>
             <td class="px-4 py-3">
-              <div class="text-sm text-text-secondary">
+              <div class="text-sm text-gray-500">
                 <div>
                   {{ s.free_episode_count }} free
                 </div>
@@ -423,7 +423,7 @@ onMounted(() => {
                 </div>
               </div>
             </td>
-            <td class="px-4 py-3 text-sm text-text-secondary">
+            <td class="px-4 py-3 text-sm text-gray-500">
               {{ formatDate(s.created_at) }}
             </td>
             <td class="px-4 py-3 text-right">
@@ -431,14 +431,14 @@ onMounted(() => {
                 as="div"
                 class="relative inline-block text-left"
               >
-                <MenuButton class="text-text-secondary hover:text-text-primary transition-colors">
+                <MenuButton class="text-gray-400 hover:text-gray-700 transition-colors">
                   <EllipsisVerticalIcon class="h-5 w-5" />
                 </MenuButton>
-                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-bg-secondary border border-border shadow-lg focus:outline-none">
+                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-white border border-border shadow-lg focus:outline-none">
                   <div class="py-1">
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-text-primary flex items-center gap-2']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-gray-700 flex items-center gap-2']"
                         @click="router.push(`/series/${s.id}/edit`)"
                       >
                         <PencilIcon class="h-4 w-4" />
@@ -450,7 +450,7 @@ onMounted(() => {
                       v-slot="{ active }"
                     >
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-amber-400 flex items-center gap-2']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-amber-600 flex items-center gap-2']"
                         @click="openDeleteConfirm(s, 'archive')"
                       >
                         <ArchiveBoxIcon class="h-4 w-4" />
@@ -459,7 +459,7 @@ onMounted(() => {
                     </MenuItem>
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-destructive flex items-center gap-2']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-destructive flex items-center gap-2']"
                         @click="openDeleteConfirm(s, 'delete')"
                       >
                         <TrashIcon class="h-4 w-4" />
@@ -480,11 +480,13 @@ onMounted(() => {
       v-else
       class="text-center py-12"
     >
-      <PhotoIcon class="mx-auto h-12 w-12 text-text-secondary mb-4" />
-      <h3 class="text-lg font-medium text-text-primary mb-2">
+      <div class="mx-auto h-12 w-12 rounded-full bg-gray-50 flex items-center justify-center mb-4">
+        <PhotoIcon class="h-6 w-6 text-gray-400" />
+      </div>
+      <h3 class="text-lg font-medium text-gray-900 mb-2">
         No series found
       </h3>
-      <p class="text-text-secondary mb-6">
+      <p class="text-gray-500 mb-6">
         {{ searchQuery || statusFilter !== 'all' || selectedTag ? 'Try adjusting your filters' : 'Get started by creating your first series' }}
       </p>
       <button
@@ -502,20 +504,20 @@ onMounted(() => {
       v-if="!loading && totalPages > 1"
       class="flex items-center justify-between mt-6"
     >
-      <div class="text-sm text-text-secondary">
+      <div class="text-sm text-gray-500">
         Page {{ page }} of {{ totalPages }}
       </div>
       <div class="flex gap-2">
         <button
           :disabled="!hasPrevious"
-          class="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-bg-tertiary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          class="rounded-lg bg-white border border-border px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           @click="goToPreviousPage"
         >
           Previous
         </button>
         <button
           :disabled="!hasNext"
-          class="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary hover:bg-bg-tertiary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          class="rounded-lg bg-white border border-border px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           @click="goToNextPage"
         >
           Next
@@ -526,31 +528,33 @@ onMounted(() => {
     <!-- Delete/Archive Confirmation Modal -->
     <div
       v-if="showDeleteConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
-          {{ deleteAction === 'archive' ? 'Archive' : 'Delete' }} Series
-        </h2>
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl w-full max-w-md overflow-hidden">
+        <div class="p-6">
+          <h2 class="text-lg font-semibold text-gray-900 mb-4">
+            {{ deleteAction === 'archive' ? 'Archive' : 'Delete' }} Series
+          </h2>
 
-        <p class="text-text-secondary mb-4">
-          Are you sure you want to {{ deleteAction }} the series "{{ deletingSeries?.title }}"?
-          <span v-if="deleteAction === 'delete'">
-            This action cannot be undone.
-          </span>
-        </p>
+          <p class="text-gray-500 mb-4">
+            Are you sure you want to {{ deleteAction }} the series "{{ deletingSeries?.title }}"?
+            <span v-if="deleteAction === 'delete'">
+              This action cannot be undone.
+            </span>
+          </p>
 
-        <div
-          v-if="deleteError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
-        >
-          {{ deleteError }}
+          <div
+            v-if="deleteError"
+            class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          >
+            {{ deleteError }}
+          </div>
         </div>
 
-        <div class="flex justify-end gap-3">
+        <div class="flex justify-end gap-3 bg-gray-50 px-6 py-4">
           <button
             type="button"
-            class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+            class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
             @click="showDeleteConfirm = false"
           >
             Cancel

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -3,11 +3,13 @@
 
 <template>
   <div>
-    <h1 class="text-2xl font-bold text-text-primary mb-4">
+    <h1 class="text-2xl font-bold text-gray-900 mb-4">
       Settings
     </h1>
-    <p class="text-text-secondary">
-      Configure your application settings.
-    </p>
+    <div class="bg-white rounded-xl border border-border shadow-[--shadow-card] p-6">
+      <p class="text-gray-500">
+        Configure your application settings.
+      </p>
+    </div>
   </div>
 </template>

--- a/frontend/src/views/TagsView.vue
+++ b/frontend/src/views/TagsView.vue
@@ -178,13 +178,13 @@ async function deleteTag() {
 function getCategoryBadgeClass(category: string | null): string {
   switch (category) {
     case 'genre':
-      return 'bg-blue-500/15 text-blue-400'
+      return 'bg-blue-50 text-blue-700 border border-blue-200'
     case 'mood':
-      return 'bg-purple-500/15 text-purple-400'
+      return 'bg-purple-50 text-purple-700 border border-purple-200'
     case 'language':
-      return 'bg-green-500/15 text-green-400'
+      return 'bg-emerald-50 text-emerald-700 border border-emerald-200'
     default:
-      return 'bg-bg-tertiary text-text-secondary'
+      return 'bg-gray-100 text-gray-600 border border-gray-200'
   }
 }
 
@@ -203,7 +203,7 @@ onMounted(fetchTags)
   <div>
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-text-primary">
+      <h1 class="text-2xl font-bold text-gray-900">
         Tags
       </h1>
       <button
@@ -218,20 +218,20 @@ onMounted(fetchTags)
     <!-- Error -->
     <div
       v-if="error"
-      class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+      class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
     >
       {{ error }}
     </div>
 
     <!-- Category Filter Tabs -->
-    <div class="flex gap-1 mb-6 border-b border-border">
+    <div class="flex gap-1 mb-6 border-b border-gray-200">
       <button
         v-for="category in ['all', 'genre', 'mood', 'language']"
         :key="category"
         :class="[
           selectedCategory === category
             ? 'border-b-2 border-accent text-accent'
-            : 'text-text-secondary hover:text-text-primary',
+            : 'text-gray-500 hover:text-gray-900',
           'px-4 py-2 text-sm font-medium capitalize transition-colors',
         ]"
         @click="selectedCategory = category as any"
@@ -246,16 +246,16 @@ onMounted(fetchTags)
     <!-- Create Tag Modal -->
     <div
       v-if="showCreateForm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">
           Create Tag
         </h2>
 
         <div
           v-if="createError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
         >
           {{ createError }}
         </div>
@@ -265,20 +265,20 @@ onMounted(fetchTags)
           @submit.prevent="createTag"
         >
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Name</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
             <input
               v-model="createName"
               type="text"
               required
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
               placeholder="Enter tag name"
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Category</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
             <select
               v-model="createCategory"
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
               <option value="">
                 None
@@ -298,7 +298,7 @@ onMounted(fetchTags)
           <div class="flex justify-end gap-3 pt-2">
             <button
               type="button"
-              class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+              class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               @click="showCreateForm = false"
             >
               Cancel
@@ -318,16 +318,16 @@ onMounted(fetchTags)
     <!-- Edit Tag Modal -->
     <div
       v-if="showEditForm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">
           Edit Tag
         </h2>
 
         <div
           v-if="editError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
         >
           {{ editError }}
         </div>
@@ -337,19 +337,19 @@ onMounted(fetchTags)
           @submit.prevent="updateTag"
         >
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Name</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
             <input
               v-model="editName"
               type="text"
               required
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Category</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Category</label>
             <select
               v-model="editCategory"
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
               <option value="">
                 None
@@ -369,7 +369,7 @@ onMounted(fetchTags)
           <div class="flex justify-end gap-3 pt-2">
             <button
               type="button"
-              class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+              class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               @click="showEditForm = false"
             >
               Cancel
@@ -389,20 +389,20 @@ onMounted(fetchTags)
     <!-- Delete Confirmation Modal -->
     <div
       v-if="showDeleteConfirm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">
           Delete Tag
         </h2>
 
-        <p class="text-text-secondary mb-4">
+        <p class="text-gray-500 mb-4">
           Are you sure you want to delete the tag "{{ deletingTag?.name }}"? This action cannot be undone.
         </p>
 
         <div
           v-if="deleteError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
         >
           {{ deleteError }}
         </div>
@@ -410,7 +410,7 @@ onMounted(fetchTags)
         <div class="flex justify-end gap-3">
           <button
             type="button"
-            class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+            class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
             @click="showDeleteConfirm = false"
           >
             Cancel
@@ -429,57 +429,57 @@ onMounted(fetchTags)
     <!-- Loading Skeleton -->
     <div
       v-if="loading"
-      class="overflow-hidden rounded-xl border border-border animate-pulse"
+      class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card] animate-pulse"
     >
-      <div class="border-b border-border bg-bg-secondary px-4 py-3">
-        <div class="h-4 w-32 bg-bg-tertiary rounded" />
+      <div class="border-b border-gray-200 bg-[#F9FAFB] px-4 py-3">
+        <div class="h-4 w-32 bg-gray-200 rounded" />
       </div>
       <div
         v-for="i in 5"
         :key="i"
-        class="flex items-center gap-4 px-4 py-3 border-b border-border last:border-0"
+        class="flex items-center gap-4 px-4 py-3 border-b border-gray-200 last:border-0"
       >
         <div class="flex-1">
-          <div class="h-4 w-28 bg-bg-tertiary rounded" />
+          <div class="h-4 w-28 bg-gray-200 rounded" />
         </div>
-        <div class="h-5 w-16 bg-bg-tertiary rounded-full" />
-        <div class="h-4 w-20 bg-bg-tertiary rounded" />
+        <div class="h-5 w-16 bg-gray-200 rounded-full" />
+        <div class="h-4 w-20 bg-gray-200 rounded" />
       </div>
     </div>
 
     <!-- Tags Table -->
     <div
       v-else-if="filteredTags.length > 0"
-      class="overflow-hidden rounded-xl border border-border"
+      class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card]"
     >
       <table class="w-full">
         <thead>
-          <tr class="border-b border-border bg-bg-secondary">
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+          <tr class="border-b border-gray-200 bg-[#F9FAFB]">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Name
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Category
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Created
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Updated
             </th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-border">
+        <tbody class="divide-y divide-gray-200">
           <tr
             v-for="tag in filteredTags"
             :key="tag.id"
-            class="hover:bg-bg-secondary/50 transition-colors"
+            class="hover:bg-gray-50 transition-colors"
           >
             <td class="px-4 py-3">
-              <span class="text-sm font-medium text-text-primary">{{ tag.name }}</span>
+              <span class="text-sm font-medium text-gray-900">{{ tag.name }}</span>
             </td>
             <td class="px-4 py-3">
               <span
@@ -491,10 +491,10 @@ onMounted(fetchTags)
                 {{ tag.category || 'Uncategorized' }}
               </span>
             </td>
-            <td class="px-4 py-3 text-sm text-text-secondary">
+            <td class="px-4 py-3 text-sm text-gray-500">
               {{ formatDate(tag.created_at) }}
             </td>
-            <td class="px-4 py-3 text-sm text-text-secondary">
+            <td class="px-4 py-3 text-sm text-gray-500">
               {{ formatDate(tag.updated_at) }}
             </td>
             <td class="px-4 py-3 text-right">
@@ -502,14 +502,14 @@ onMounted(fetchTags)
                 as="div"
                 class="relative inline-block text-left"
               >
-                <MenuButton class="text-text-secondary hover:text-text-primary transition-colors">
+                <MenuButton class="text-gray-400 hover:text-gray-600 transition-colors">
                   <EllipsisVerticalIcon class="h-5 w-5" />
                 </MenuButton>
-                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-bg-secondary border border-border shadow-lg focus:outline-none">
+                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-white border border-gray-200 shadow-[--shadow-dropdown] focus:outline-none">
                   <div class="py-1">
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-text-primary flex items-center gap-2']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-gray-700 flex items-center gap-2']"
                         @click="openEditForm(tag)"
                       >
                         <PencilIcon class="h-4 w-4" />
@@ -518,7 +518,7 @@ onMounted(fetchTags)
                     </MenuItem>
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-destructive flex items-center gap-2']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-red-600 flex items-center gap-2']"
                         @click="openDeleteConfirm(tag)"
                       >
                         <TrashIcon class="h-4 w-4" />
@@ -539,7 +539,7 @@ onMounted(fetchTags)
       v-else
       class="text-center py-12"
     >
-      <p class="text-text-secondary">
+      <p class="text-gray-500">
         No tags found{{ selectedCategory !== 'all' ? ` in ${selectedCategory} category` : '' }}.
       </p>
     </div>

--- a/frontend/src/views/UsersView.vue
+++ b/frontend/src/views/UsersView.vue
@@ -111,7 +111,7 @@ onMounted(fetchUsers)
   <div>
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-text-primary">
+      <h1 class="text-2xl font-bold text-gray-900">
         Users
       </h1>
       <button
@@ -126,7 +126,7 @@ onMounted(fetchUsers)
     <!-- Error -->
     <div
       v-if="error"
-      class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+      class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
     >
       {{ error }}
     </div>
@@ -134,16 +134,16 @@ onMounted(fetchUsers)
     <!-- Invite Form Modal -->
     <div
       v-if="showInviteForm"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/75 backdrop-blur-sm"
     >
-      <div class="bg-bg-secondary border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-primary mb-4">
+      <div class="bg-white border border-gray-100 rounded-xl shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">
           Invite User
         </h2>
 
         <div
           v-if="inviteError"
-          class="bg-destructive/10 border border-destructive/30 text-destructive rounded-lg px-4 py-3 text-sm mb-4"
+          class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm mb-4"
         >
           {{ inviteError }}
         </div>
@@ -153,37 +153,37 @@ onMounted(fetchUsers)
           @submit.prevent="inviteUser"
         >
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Email</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
             <input
               v-model="inviteEmail"
               type="email"
               required
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Name</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Name</label>
             <input
               v-model="inviteName"
               type="text"
               required
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Temporary Password</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Temporary Password</label>
             <input
               v-model="invitePassword"
               type="password"
               required
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] placeholder-gray-400 focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
           </div>
           <div>
-            <label class="block text-sm font-medium text-text-secondary mb-1">Role</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Role</label>
             <select
               v-model="inviteRole"
-              class="w-full rounded-lg border border-border bg-bg-tertiary px-3 py-2 text-text-primary focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
+              class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-gray-900 shadow-[--shadow-input] focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent"
             >
               <option value="editor">
                 Editor
@@ -197,7 +197,7 @@ onMounted(fetchUsers)
           <div class="flex justify-end gap-3 pt-2">
             <button
               type="button"
-              class="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-secondary hover:bg-bg-tertiary transition-colors"
+              class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
               @click="showInviteForm = false"
             >
               Cancel
@@ -217,79 +217,79 @@ onMounted(fetchUsers)
     <!-- Loading Skeleton -->
     <div
       v-if="loading"
-      class="overflow-hidden rounded-xl border border-border animate-pulse"
+      class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card] animate-pulse"
     >
-      <div class="border-b border-border bg-bg-secondary px-4 py-3">
-        <div class="h-4 w-32 bg-bg-tertiary rounded" />
+      <div class="border-b border-gray-200 bg-[#F9FAFB] px-4 py-3">
+        <div class="h-4 w-32 bg-gray-200 rounded" />
       </div>
       <div
         v-for="i in 5"
         :key="i"
-        class="flex items-center gap-4 px-4 py-3 border-b border-border last:border-0"
+        class="flex items-center gap-4 px-4 py-3 border-b border-gray-200 last:border-0"
       >
         <div class="flex-1">
-          <div class="h-4 w-32 bg-bg-tertiary rounded mb-1" />
-          <div class="h-3 w-48 bg-bg-tertiary rounded" />
+          <div class="h-4 w-32 bg-gray-200 rounded mb-1" />
+          <div class="h-3 w-48 bg-gray-200 rounded" />
         </div>
-        <div class="h-5 w-14 bg-bg-tertiary rounded-full" />
-        <div class="h-5 w-14 bg-bg-tertiary rounded-full" />
+        <div class="h-5 w-14 bg-gray-200 rounded-full" />
+        <div class="h-5 w-14 bg-gray-200 rounded-full" />
       </div>
     </div>
 
     <!-- Users Table -->
     <div
       v-else
-      class="overflow-hidden rounded-xl border border-border"
+      class="overflow-hidden rounded-xl border border-border bg-white shadow-[--shadow-card]"
     >
       <table class="w-full">
         <thead>
-          <tr class="border-b border-border bg-bg-secondary">
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+          <tr class="border-b border-gray-200 bg-[#F9FAFB]">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Name
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Email
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Role
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Status
             </th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Joined
             </th>
-            <th class="px-4 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
+            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
               Actions
             </th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-border">
+        <tbody class="divide-y divide-gray-200">
           <tr
             v-for="u in users"
             :key="u.id"
-            class="hover:bg-bg-secondary/50 transition-colors"
+            class="hover:bg-gray-50 transition-colors"
           >
             <td class="px-4 py-3">
               <div class="flex items-center gap-2">
-                <span class="text-sm font-medium text-text-primary">{{ u.name }}</span>
+                <span class="text-sm font-medium text-gray-900">{{ u.name }}</span>
                 <span
                   v-if="u.oauth_provider"
-                  class="inline-flex items-center rounded-full bg-bg-tertiary px-2 py-0.5 text-xs text-text-secondary"
+                  class="inline-flex items-center rounded-full bg-gray-100 border border-gray-200 px-2 py-0.5 text-xs text-gray-500"
                 >
                   {{ u.oauth_provider }}
                 </span>
               </div>
             </td>
-            <td class="px-4 py-3 text-sm text-text-secondary">
+            <td class="px-4 py-3 text-sm text-gray-500">
               {{ u.email }}
             </td>
             <td class="px-4 py-3">
               <span
                 :class="[
                   u.role === 'admin'
-                    ? 'bg-accent/15 text-accent'
-                    : 'bg-bg-tertiary text-text-secondary',
+                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    : 'bg-blue-50 text-blue-700 border border-blue-200',
                   'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
                 ]"
               >
@@ -300,15 +300,15 @@ onMounted(fetchUsers)
               <span
                 :class="[
                   u.is_active
-                    ? 'bg-green-500/15 text-green-400'
-                    : 'bg-destructive/15 text-destructive',
+                    ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
+                    : 'bg-red-50 text-red-700 border border-red-200',
                   'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
                 ]"
               >
                 {{ u.is_active ? 'Active' : 'Disabled' }}
               </span>
             </td>
-            <td class="px-4 py-3 text-sm text-text-secondary">
+            <td class="px-4 py-3 text-sm text-gray-500">
               {{ formatDate(u.created_at) }}
             </td>
             <td class="px-4 py-3 text-right">
@@ -316,14 +316,14 @@ onMounted(fetchUsers)
                 as="div"
                 class="relative inline-block text-left"
               >
-                <MenuButton class="text-text-secondary hover:text-text-primary transition-colors">
+                <MenuButton class="text-gray-400 hover:text-gray-600 transition-colors">
                   <EllipsisVerticalIcon class="h-5 w-5" />
                 </MenuButton>
-                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-bg-secondary border border-border shadow-lg focus:outline-none">
+                <MenuItems class="absolute right-0 z-10 mt-2 w-48 rounded-lg bg-white border border-gray-200 shadow-[--shadow-dropdown] focus:outline-none">
                   <div class="py-1">
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm text-text-primary']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm text-gray-700']"
                         @click="changeRole(u.id, u.role === 'admin' ? 'editor' : 'admin')"
                       >
                         Make {{ u.role === 'admin' ? 'Editor' : 'Admin' }}
@@ -331,7 +331,7 @@ onMounted(fetchUsers)
                     </MenuItem>
                     <MenuItem v-slot="{ active }">
                       <button
-                        :class="[active ? 'bg-bg-tertiary' : '', 'block w-full px-4 py-2 text-left text-sm', u.is_active ? 'text-destructive' : 'text-green-400']"
+                        :class="[active ? 'bg-gray-50' : '', 'block w-full px-4 py-2 text-left text-sm', u.is_active ? 'text-red-600' : 'text-emerald-600']"
                         @click="toggleActive(u.id, u.is_active)"
                       >
                         {{ u.is_active ? 'Disable Account' : 'Enable Account' }}


### PR DESCRIPTION
## Summary

- **Complete theme overhaul** from dark (#0A0A0A backgrounds) to professional light (#F8F9FA) admin panel matching the HTML reference designs in `docs/references/`
- **Dark navy sidebar** (#0F172A) with section headers (Overview, Content, Users, System), green play-icon logo, active state with green left border, and user initials avatar
- **Glass header** with frosted blur effect, notification bell indicator, language switcher, and repositioned global search
- **All 22 Vue files updated**: theme tokens in main.css, layout components, all views (Dashboard, Series, Episodes, Tags, Users, Login, Settings), shared UI components (Toast, ConfirmDialog, EmptyState, ErrorState, LoadingSkeleton), and form components
- **Tests updated** (2 files) to match new light-theme CSS classes — all 92 tests passing

## Test plan

- [x] `npm run build` — clean, no errors
- [x] `npm run type-check` — clean, no errors
- [x] `npm run lint` — 0 errors (1 pre-existing coverage warning)
- [x] `npm run test:ci` — 14/14 test files, 92/92 tests passing
- [ ] Visual inspection at desktop (1280px+): dark navy sidebar, glass header, white stat cards with shadows
- [ ] Visual inspection at tablet (768px): responsive layout, collapsible sidebar
- [ ] Visual inspection at mobile (375px): hamburger menu, stacked layouts
- [ ] Verify all page transitions: Dashboard → Series → Detail → Edit → Episodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)