### PR TITLE
fix: series page hero image, completion %, and vertical swipe video player

### DIFF
--- a/mobile/src/components/sheets/CoinPackSheet.tsx
+++ b/mobile/src/components/sheets/CoinPackSheet.tsx
@@ -1,0 +1,229 @@
+import React, {useCallback} from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Dimensions,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {usePackages, useBalance, usePurchaseMutation} from '../../hooks/useCoins';
+import {colors, fontSizes, fontWeights, spacing, radii} from '../../theme';
+import type {CoinPackageResponse} from '../../types/api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CoinPackSheetProps {
+  /** Called when user taps overlay or back to dismiss this sheet */
+  onDismiss: () => void;
+  /** Called after a successful purchase — parent can update balance display */
+  onPurchased: () => void;
+}
+
+const {height: SCREEN_HEIGHT, width: SCREEN_WIDTH} = Dimensions.get('window');
+const SHEET_MAX_HEIGHT = SCREEN_HEIGHT * 0.6;
+const CARD_GAP = spacing.md;
+const CARD_WIDTH = (SCREEN_WIDTH - spacing.lg * 2 - CARD_GAP) / 2;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function CoinPackSheet({onDismiss, onPurchased}: CoinPackSheetProps) {
+  const insets = useSafeAreaInsets();
+  const {data: packages, isLoading: packagesLoading} = usePackages();
+  const {data: balanceData} = useBalance();
+  const purchaseMutation = usePurchaseMutation();
+
+  const balance = balanceData?.balance ?? 0;
+
+  const handlePurchase = useCallback(
+    (pkg: CoinPackageResponse) => {
+      Alert.alert(
+        '\u0634\u0631\u0627\u0621 \u0639\u0645\u0644\u0627\u062A',
+        `${pkg.coin_amount} \u0639\u0645\u0644\u0629 \u0628\u0640 ${pkg.price_sar} \u0631.\u0633`,
+        [
+          {text: '\u0625\u0644\u063A\u0627\u0621', style: 'cancel'},
+          {
+            text: '\u0634\u0631\u0627\u0621',
+            onPress: () => {
+              purchaseMutation.mutate(
+                {packageId: pkg.id, coinAmount: pkg.coin_amount},
+                {onSuccess: () => onPurchased()},
+              );
+            },
+          },
+        ],
+      );
+    },
+    [purchaseMutation, onPurchased],
+  );
+
+  const renderItem = useCallback(
+    ({item}: {item: CoinPackageResponse}) => (
+      <Pressable
+        style={({pressed}) => [styles.packCard, pressed && styles.packCardPressed]}
+        onPress={() => handlePurchase(item)}>
+        <Text style={styles.packCoins}>{'\uD83E\uDE99'} {item.coin_amount}</Text>
+        {item.description && (
+          <Text style={styles.packBonus}>{item.description}</Text>
+        )}
+        <Text style={styles.packPrice}>{item.price_sar} {'\u0631.\u0633'}</Text>
+      </Pressable>
+    ),
+    [handlePurchase],
+  );
+
+  const keyExtractor = useCallback((item: CoinPackageResponse) => item.id, []);
+
+  return (
+    <View style={styles.root}>
+      <Pressable style={styles.overlay} onPress={onDismiss} />
+
+      <View
+        style={[
+          styles.sheet,
+          {maxHeight: SHEET_MAX_HEIGHT, paddingBottom: insets.bottom + spacing.lg},
+        ]}>
+        {/* Drag handle */}
+        <View style={styles.dragHandleWrapper}>
+          <View style={styles.dragHandle} />
+        </View>
+
+        {/* Header */}
+        <View style={styles.header}>
+          <Pressable onPress={onDismiss} hitSlop={8}>
+            <Text style={styles.backArrow}>{'\u276F'}</Text>
+          </Pressable>
+          <Text style={styles.headerTitle}>
+            {'\u0634\u0631\u0627\u0621 \u0639\u0645\u0644\u0627\u062A'}
+          </Text>
+          <View style={styles.headerSpacer} />
+        </View>
+
+        {/* Current balance */}
+        <Text style={styles.currentBalance}>
+          {'\u0631\u0635\u064A\u062F\u0643:'} {balance} {'\uD83E\uDE99'}
+        </Text>
+
+        {/* Packages grid */}
+        {packagesLoading ? (
+          <ActivityIndicator size="large" color={colors.cta} style={styles.loading} />
+        ) : (
+          <FlatList
+            data={packages}
+            renderItem={renderItem}
+            keyExtractor={keyExtractor}
+            numColumns={2}
+            columnWrapperStyle={styles.gridRow}
+            contentContainerStyle={styles.gridContent}
+            showsVerticalScrollIndicator={false}
+          />
+        )}
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    zIndex: 200,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: radii.sheet,
+    borderTopRightRadius: radii.sheet,
+    overflow: 'hidden',
+  },
+  dragHandleWrapper: {
+    alignItems: 'center',
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.border,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+  },
+  backArrow: {
+    fontSize: 16,
+    color: colors.text,
+  },
+  headerTitle: {
+    flex: 1,
+    fontSize: fontSizes.sectionTitle,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    textAlign: 'center',
+    writingDirection: 'rtl',
+  },
+  headerSpacer: {
+    width: 16,
+  },
+  currentBalance: {
+    fontSize: fontSizes.body,
+    color: colors.coin,
+    textAlign: 'center',
+    writingDirection: 'rtl',
+    marginBottom: spacing.lg,
+  },
+  loading: {
+    marginTop: spacing.xl,
+  },
+  gridContent: {
+    paddingHorizontal: spacing.lg,
+  },
+  gridRow: {
+    gap: CARD_GAP,
+    marginBottom: CARD_GAP,
+  },
+  packCard: {
+    width: CARD_WIDTH,
+    backgroundColor: colors.cardElevated,
+    borderRadius: radii.card,
+    padding: spacing.lg,
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  packCardPressed: {
+    opacity: 0.7,
+  },
+  packCoins: {
+    fontSize: fontSizes.sectionTitle,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+  },
+  packBonus: {
+    fontSize: fontSizes.caption,
+    color: colors.cta,
+    writingDirection: 'rtl',
+  },
+  packPrice: {
+    fontSize: fontSizes.body,
+    fontWeight: fontWeights.semibold,
+    color: colors.coin,
+    marginTop: spacing.sm,
+  },
+});

--- a/mobile/src/components/sheets/UnlockEpisodeSheet.tsx
+++ b/mobile/src/components/sheets/UnlockEpisodeSheet.tsx
@@ -1,0 +1,296 @@
+import React, {useCallback, useState} from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  StyleSheet,
+  Dimensions,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {useBalance, useSpendMutation} from '../../hooks/useCoins';
+import {colors, fontSizes, fontWeights, spacing, radii, sizes} from '../../theme';
+import type {AxiosError} from 'axios';
+import CoinPackSheet from './CoinPackSheet';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface UnlockEpisodeSheetProps {
+  episodeId: string;
+  episodeNumber: number;
+  episodeTitle: string;
+  coinCost: number;
+  /** Called after successful unlock — parent should start playing the episode */
+  onUnlocked: () => void;
+  /** Called when user dismisses the sheet */
+  onDismiss: () => void;
+}
+
+const {height: SCREEN_HEIGHT} = Dimensions.get('window');
+const SHEET_MAX_HEIGHT = SCREEN_HEIGHT * 0.65;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function UnlockEpisodeSheet({
+  episodeId,
+  episodeNumber,
+  episodeTitle,
+  coinCost,
+  onUnlocked,
+  onDismiss,
+}: UnlockEpisodeSheetProps) {
+  const insets = useSafeAreaInsets();
+  const {data: balanceData, isLoading: balanceLoading} = useBalance();
+  const spendMutation = useSpendMutation();
+  const [showCoinPacks, setShowCoinPacks] = useState(false);
+
+  const balance = balanceData?.balance ?? 0;
+  const canAfford = balance >= coinCost;
+
+  const handleUnlock = useCallback(() => {
+    spendMutation.mutate(
+      {episodeId, cost: coinCost},
+      {
+        onSuccess: () => onUnlocked(),
+        onError: (error) => {
+          const status = (error as AxiosError)?.response?.status;
+          if (status === 409) {
+            // Already unlocked
+            onUnlocked();
+          } else {
+            Alert.alert(
+              '\u062E\u0637\u0623',
+              '\u062D\u062F\u062B \u062E\u0637\u0623 \u0623\u062B\u0646\u0627\u0621 \u0641\u062A\u062D \u0627\u0644\u062D\u0644\u0642\u0629',
+            );
+          }
+        },
+      },
+    );
+  }, [episodeId, coinCost, spendMutation, onUnlocked]);
+
+  // When coin packs are visible, show that sheet instead
+  if (showCoinPacks) {
+    return (
+      <CoinPackSheet
+        onDismiss={() => setShowCoinPacks(false)}
+        onPurchased={() => setShowCoinPacks(false)}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.root}>
+      {/* Overlay — tapping dismisses */}
+      <Pressable style={styles.overlay} onPress={onDismiss} />
+
+      {/* Sheet */}
+      <View
+        style={[
+          styles.sheet,
+          {maxHeight: SHEET_MAX_HEIGHT, paddingBottom: insets.bottom + spacing.lg},
+        ]}>
+        {/* Drag handle */}
+        <View style={styles.dragHandleWrapper}>
+          <View style={styles.dragHandle} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+          bounces={false}>
+          {/* Lock icon */}
+          <View style={styles.lockIconWrapper}>
+            <View style={styles.lockGlow} />
+            <Text style={styles.lockIcon}>{'\uD83D\uDD12'}</Text>
+          </View>
+
+          {/* Episode info */}
+          <Text style={styles.episodeInfo}>
+            {'\u062D'} {episodeNumber} — {episodeTitle}
+          </Text>
+
+          {/* Locked heading */}
+          <Text style={styles.lockedHeading}>
+            {'\u0647\u0630\u0647 \u0627\u0644\u062D\u0644\u0642\u0629 \u0645\u0642\u0641\u0644\u0629'}
+          </Text>
+
+          {/* Unlock button */}
+          <Pressable
+            style={[
+              styles.unlockButton,
+              (!canAfford || spendMutation.isPending) && styles.unlockButtonDisabled,
+            ]}
+            onPress={handleUnlock}
+            disabled={!canAfford || spendMutation.isPending}>
+            {spendMutation.isPending ? (
+              <ActivityIndicator size="small" color={colors.text} />
+            ) : (
+              <>
+                <Text style={styles.unlockCoinIcon}>{'\uD83E\uDE99'}</Text>
+                <Text style={styles.unlockButtonText}>
+                  {'\u0627\u0641\u062A\u062D \u0628\u0640'} {coinCost}{' '}
+                  {'\u0639\u0645\u0644\u0627\u062A'}
+                </Text>
+              </>
+            )}
+          </Pressable>
+
+          {/* Balance display */}
+          {balanceLoading ? (
+            <ActivityIndicator size="small" color={colors.coin} style={styles.balanceLoading} />
+          ) : (
+            <Text style={[styles.balanceText, !canAfford && styles.balanceInsufficient]}>
+              {'\u0631\u0635\u064A\u062F\u0643:'} {balance} {'\u0639\u0645\u0644\u0629'}
+            </Text>
+          )}
+
+          {/* Get more coins link when insufficient */}
+          {!canAfford && !balanceLoading && (
+            <Pressable onPress={() => setShowCoinPacks(true)} hitSlop={8}>
+              <Text style={styles.getMoreCoins}>
+                {'\u0627\u062D\u0635\u0644 \u0639\u0644\u0649 \u0639\u0645\u0644\u0627\u062A'}
+              </Text>
+            </Pressable>
+          )}
+
+          {/* Dismiss */}
+          <Pressable style={styles.dismissButton} onPress={onDismiss} hitSlop={12}>
+            <Text style={styles.dismissText}>
+              {'\u0644\u064A\u0633 \u0627\u0644\u0622\u0646'}
+            </Text>
+          </Pressable>
+        </ScrollView>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    zIndex: 100,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  },
+  sheet: {
+    backgroundColor: colors.card,
+    borderTopLeftRadius: radii.sheet,
+    borderTopRightRadius: radii.sheet,
+    overflow: 'hidden',
+  },
+  dragHandleWrapper: {
+    alignItems: 'center',
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  dragHandle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colors.border,
+  },
+  scrollContent: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.lg,
+    alignItems: 'center',
+  },
+  lockIconWrapper: {
+    width: 56,
+    height: 56,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: spacing.lg,
+    marginBottom: spacing.md,
+  },
+  lockGlow: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 28,
+    backgroundColor: 'rgba(212, 168, 67, 0.15)',
+  },
+  lockIcon: {
+    fontSize: 32,
+  },
+  episodeInfo: {
+    fontSize: fontSizes.body,
+    color: colors.textMuted,
+    writingDirection: 'rtl',
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  lockedHeading: {
+    fontSize: fontSizes.sectionTitle,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    textAlign: 'center',
+    writingDirection: 'rtl',
+    marginBottom: spacing.xl,
+  },
+  unlockButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.cta,
+    height: sizes.buttonHeight,
+    borderRadius: radii.pill,
+    gap: spacing.sm,
+    width: '100%',
+  },
+  unlockButtonDisabled: {
+    opacity: 0.5,
+  },
+  unlockCoinIcon: {
+    fontSize: 18,
+  },
+  unlockButtonText: {
+    fontSize: fontSizes.button,
+    fontWeight: fontWeights.semibold,
+    color: colors.text,
+    writingDirection: 'rtl',
+  },
+  balanceText: {
+    fontSize: fontSizes.caption,
+    color: colors.coin,
+    textAlign: 'center',
+    writingDirection: 'rtl',
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  balanceInsufficient: {
+    color: colors.error,
+  },
+  balanceLoading: {
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg,
+  },
+  getMoreCoins: {
+    fontSize: fontSizes.body,
+    fontWeight: fontWeights.semibold,
+    color: colors.cta,
+    textAlign: 'center',
+    writingDirection: 'rtl',
+    marginBottom: spacing.lg,
+  },
+  dismissButton: {
+    alignSelf: 'center',
+    paddingVertical: spacing.sm,
+    marginTop: spacing.md,
+  },
+  dismissText: {
+    fontSize: fontSizes.body,
+    color: colors.textDim,
+    writingDirection: 'rtl',
+  },
+});

--- a/mobile/src/screens/SeriesDetailScreen.tsx
+++ b/mobile/src/screens/SeriesDetailScreen.tsx
@@ -8,6 +8,7 @@ import {
   StatusBar,
   Dimensions,
   ActivityIndicator,
+  Image,
 } from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';
@@ -15,7 +16,7 @@ import {RootStackParamList} from '../navigation/types';
 import {colors, fontSizes, fontWeights, spacing, radii, sizes} from '../theme';
 import EpisodeGrid, {EpisodeData} from '../components/EpisodeGrid';
 import NowPlayingCard, {NowPlayingEpisode} from '../components/NowPlayingCard';
-import {useSeriesDetail, useIsFavorite, useToggleFavorite} from '../hooks';
+import {useSeriesDetail, useIsFavorite, useToggleFavorite, useWatchHistory} from '../hooks';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,6 +66,7 @@ export default function SeriesDetailScreen({navigation, route}: Props) {
   const toggleFavorite = useToggleFavorite();
 
   const {data: series, isLoading, error} = useSeriesDetail(seriesId);
+  const {data: historyData} = useWatchHistory();
 
   const heroHeight = Dimensions.get('window').height * HERO_HEIGHT_RATIO;
 
@@ -144,14 +146,15 @@ export default function SeriesDetailScreen({navigation, route}: Props) {
   const freeEpisodes = series?.free_episode_count || 0;
   const coinCostPerEpisode = series?.coin_cost_per_episode || 0;
 
-  // Calculate completion rate from unlocked episodes
+  // Calculate completion rate from watch history
   const completionRate = useMemo(() => {
-    if (!episodes.length) return 0;
-    const unlockedCount = episodes.filter(
-      ep => ep.state === 'watched' || ep.state === 'current' || ep.state === 'free'
+    if (!series?.episodes?.length || !historyData?.items?.length) return 0;
+    const seriesEpisodeIds = new Set(series.episodes.map(ep => ep.id));
+    const completedCount = historyData.items.filter(
+      h => seriesEpisodeIds.has(h.episode_id) && h.completed,
     ).length;
-    return Math.round((unlockedCount / episodes.length) * 100);
-  }, [episodes]);
+    return Math.round((completedCount / series.episodes.length) * 100);
+  }, [series, historyData]);
 
   // Loading state
   if (isLoading) {
@@ -189,8 +192,16 @@ export default function SeriesDetailScreen({navigation, route}: Props) {
         {/* Hero Section */}
         {/* ---------------------------------------------------------------- */}
         <View style={[styles.hero, {height: heroHeight}]}>
-          {/* Banner placeholder */}
-          <View style={styles.heroBanner} />
+          {/* Banner image */}
+          {series.thumbnail_url ? (
+            <Image
+              source={{uri: series.thumbnail_url}}
+              style={styles.heroBanner}
+              resizeMode="cover"
+            />
+          ) : (
+            <View style={styles.heroBanner} />
+          )}
 
           {/* Gradient overlay */}
           <View style={styles.heroGradientTop} />
@@ -281,7 +292,7 @@ export default function SeriesDetailScreen({navigation, route}: Props) {
               </View>
               <Text style={styles.completionText}>
                 {completionRate}%{' '}
-                {'\u0645\u0646 \u0627\u0644\u0645\u0634\u0627\u0647\u062F\u064A\u0646 \u0623\u0643\u0645\u0644\u0648\u0627 \u0647\u0630\u0627 \u0627\u0644\u0645\u0633\u0644\u0633\u0644'}
+                {'\u0623\u0643\u0645\u0644\u062A \u0645\u0646 \u0627\u0644\u0645\u0633\u0644\u0633\u0644'}
               </Text>
             </View>
           )}

--- a/mobile/src/screens/VideoPlayerScreen.tsx
+++ b/mobile/src/screens/VideoPlayerScreen.tsx
@@ -17,6 +17,13 @@ import Video, {
   type SelectedTrack,
   SelectedTrackType,
 } from 'react-native-video';
+import {GestureDetector, Gesture} from 'react-native-gesture-handler';
+import ReAnimated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+} from 'react-native-reanimated';
 import type {NativeStackScreenProps} from '@react-navigation/native-stack';
 import type {RootStackParamList} from '../navigation/types';
 import {useEpisodeDetail} from '../hooks/useEpisodes';
@@ -24,6 +31,7 @@ import {useSeriesEpisodes} from '../hooks/useSeries';
 import {useReportProgress} from '../hooks/useHistory';
 import type {EpisodeListItem, AudioTrackItem, SubtitleItem} from '../types/api';
 import {colors, fontSizes, fontWeights, spacing, radii} from '../theme';
+import UnlockEpisodeSheet from '../components/sheets/UnlockEpisodeSheet';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,7 +43,8 @@ type Props = NativeStackScreenProps<RootStackParamList, 'VideoPlayer'>;
 // Constants
 // ---------------------------------------------------------------------------
 
-const {width: SCREEN_WIDTH} = Dimensions.get('window');
+const {width: SCREEN_WIDTH, height: SCREEN_HEIGHT} = Dimensions.get('window');
+const SWIPE_THRESHOLD = 80;
 
 const CONTROLS_HIDE_DELAY = 3000;
 const AUTO_NEXT_COUNTDOWN = 5;
@@ -102,19 +111,6 @@ const VideoPlayerScreen: React.FC<Props> = ({navigation, route}) => {
   const prevEpisode = findAdjacentEpisode('prev');
 
   // ---------------------------------------------------------------------------
-  // Redirect locked episodes
-  // ---------------------------------------------------------------------------
-
-  useEffect(() => {
-    if (episode && episode.locked && !episode.is_free) {
-      navigation.replace('LockedEpisode', {
-        episodeId: episode.id,
-        coinCost: episode.coin_cost,
-      });
-    }
-  }, [episode, navigation]);
-
-  // ---------------------------------------------------------------------------
   // Playback state
   // ---------------------------------------------------------------------------
 
@@ -136,6 +132,15 @@ const VideoPlayerScreen: React.FC<Props> = ({navigation, route}) => {
   const [showTrackPicker, setShowTrackPicker] = useState<
     'audio' | 'subtitle' | null
   >(null);
+
+  // Swipe navigation
+  const translateY = useSharedValue(0);
+  const [lockedEpisodeInfo, setLockedEpisodeInfo] = useState<{
+    episodeId: string;
+    episodeNumber: number;
+    episodeTitle: string;
+    coinCost: number;
+  } | null>(null);
 
   // Animated opacity for controls overlay
   const controlsOpacity = useRef(new Animated.Value(1)).current;
@@ -397,6 +402,90 @@ const VideoPlayerScreen: React.FC<Props> = ({navigation, route}) => {
     showControlsFn();
   }, [showControlsFn]);
 
+  // ---------------------------------------------------------------------------
+  // Swipe episode navigation
+  // ---------------------------------------------------------------------------
+
+  const handleSwipeToEpisode = useCallback(
+    (direction: 'next' | 'prev') => {
+      const targetEpisode = direction === 'next' ? nextEpisode : prevEpisode;
+      if (!targetEpisode) return;
+
+      // Check if the target episode is locked
+      if (!targetEpisode.is_free && !targetEpisode.is_unlocked) {
+        setLockedEpisodeInfo({
+          episodeId: targetEpisode.id,
+          episodeNumber: targetEpisode.episode_number,
+          episodeTitle: targetEpisode.title,
+          coinCost: targetEpisode.coin_price ?? 0,
+        });
+        return;
+      }
+
+      // Navigate to the episode
+      if (direction === 'next') {
+        goToNextEpisode();
+      } else {
+        goToPreviousEpisode();
+      }
+    },
+    [nextEpisode, prevEpisode, goToNextEpisode, goToPreviousEpisode],
+  );
+
+  const handleLockedUnlocked = useCallback(() => {
+    if (!lockedEpisodeInfo) return;
+    // After unlock, switch to the episode
+    const unlockedId = lockedEpisodeInfo.episodeId;
+    setLockedEpisodeInfo(null);
+    setCurrentTime(0);
+    setDuration(0);
+    setIsPlaying(true);
+    setIsBuffering(true);
+    lastReportedTime.current = 0;
+    setCurrentEpisodeId(unlockedId);
+    showControlsFn();
+    resetHideTimer();
+  }, [lockedEpisodeInfo, showControlsFn, resetHideTimer]);
+
+  const handleLockedDismiss = useCallback(() => {
+    setLockedEpisodeInfo(null);
+  }, []);
+
+  const swipeGesture = Gesture.Pan()
+    .onUpdate((e) => {
+      if (showAutoNext || showTrackPicker) return;
+      translateY.value = e.translationY;
+    })
+    .onEnd((e) => {
+      if (showAutoNext || showTrackPicker) {
+        translateY.value = withSpring(0);
+        return;
+      }
+
+      if (e.translationY < -SWIPE_THRESHOLD && nextEpisode) {
+        // Swiped up — go to next
+        translateY.value = withSpring(-SCREEN_HEIGHT, {damping: 20}, () => {
+          translateY.value = 0;
+          runOnJS(handleSwipeToEpisode)('next');
+        });
+      } else if (e.translationY > SWIPE_THRESHOLD && prevEpisode) {
+        // Swiped down — go to prev
+        translateY.value = withSpring(SCREEN_HEIGHT, {damping: 20}, () => {
+          translateY.value = 0;
+          runOnJS(handleSwipeToEpisode)('prev');
+        });
+      } else {
+        // Snap back
+        translateY.value = withSpring(0);
+      }
+    })
+    .activeOffsetY([-20, 20])
+    .failOffsetX([-20, 20]);
+
+  const animatedPlayerStyle = useAnimatedStyle(() => ({
+    transform: [{translateY: translateY.value}],
+  }));
+
   const playNow = useCallback(() => {
     if (countdownInterval.current) {
       clearInterval(countdownInterval.current);
@@ -484,26 +573,13 @@ const VideoPlayerScreen: React.FC<Props> = ({navigation, route}) => {
     );
   }
 
-  // If locked, we'll redirect via the useEffect above — show loading while redirecting
-  if (episode.locked && !episode.is_free) {
-    return (
-      <View style={styles.root}>
-        <StatusBar hidden />
-        <ActivityIndicator
-          size="large"
-          color={colors.cta}
-          style={styles.centered}
-        />
-      </View>
-    );
-  }
-
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
 
   return (
-    <View style={styles.root}>
+    <GestureDetector gesture={swipeGesture}>
+    <ReAnimated.View style={[styles.root, animatedPlayerStyle]}>
       <StatusBar hidden />
 
       {/* Video player */}
@@ -784,7 +860,20 @@ const VideoPlayerScreen: React.FC<Props> = ({navigation, route}) => {
           </View>
         </View>
       )}
-    </View>
+
+      {/* Locked episode sheet */}
+      {lockedEpisodeInfo && (
+        <UnlockEpisodeSheet
+          episodeId={lockedEpisodeInfo.episodeId}
+          episodeNumber={lockedEpisodeInfo.episodeNumber}
+          episodeTitle={lockedEpisodeInfo.episodeTitle}
+          coinCost={lockedEpisodeInfo.coinCost}
+          onUnlocked={handleLockedUnlocked}
+          onDismiss={handleLockedDismiss}
+        />
+      )}
+    </ReAnimated.View>
+    </GestureDetector>
   );
 };
 

--- a/mobile/src/types/api.ts
+++ b/mobile/src/types/api.ts
@@ -22,6 +22,7 @@ export interface EpisodeListItem {
   thumbnail_url: string | null;
   is_free: boolean;
   is_unlocked: boolean;
+  coin_price: number;
   duration_seconds: number | null;
 }
 


### PR DESCRIPTION
## Summary
- Display hero image in SeriesDetailScreen using `series.thumbnail_url`
- Fix completion percentage to show user's own watch progress (not % of viewers)
- Add TikTok-style vertical swipe navigation in VideoPlayerScreen (up=next, down=prev)
- Show inline UnlockEpisodeSheet when swiping to a locked episode (no navigation away)
- Add CoinPackSheet for purchasing coins without leaving the player
- Add `coin_price` field to `EpisodeListItem` type

## Test plan
- [ ] Verify hero image displays on series detail page
- [ ] Verify completion bar shows user's own progress
- [ ] Swipe up on video player to go to next episode
- [ ] Swipe down to go to previous episode
- [ ] Swipe to a locked episode — unlock sheet appears
- [ ] Tap "Unlock" with sufficient coins — episode plays
- [ ] Tap "Get More Coins" — coin pack sheet appears
- [ ] Purchase coins and unlock episode inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)